### PR TITLE
fix language in UI field

### DIFF
--- a/snykTask/task.json
+++ b/snykTask/task.json
@@ -94,7 +94,7 @@
 
         {
             "name": "monitorOnBuild",
-            "label": "Run the Snyk monitor after test?",
+            "label": "Run Snyk monitor after test?",
             "type": "boolean",
             "required": true,
             "defaultValue": "true",


### PR DESCRIPTION
fix language in UI field: "Run the Snyk monitor after test?" -> "Run Snyk monitor after test?"