### PR TITLE
Fixes 'Additional Arguments' when more than 1 argument is passed.

### DIFF
--- a/snykTask/src/index.ts
+++ b/snykTask/src/index.ts
@@ -50,7 +50,7 @@ function parseInputArgs(): TaskArgs {
   taskArgs.organization = tl.getInput("organization", false);
   taskArgs.monitorOnBuild = tl.getBoolInput("monitorOnBuild", true);
   taskArgs.failOnIssues = tl.getBoolInput("failOnIssues", true);
-  taskArgs.additionalArguments = tl.getInput("additionalArguments", false);
+  taskArgs.additionalArguments = tl.getInput("additionalArguments", false) || "";
   taskArgs.testDirectory = tl.getInput("testDirectory", false);
   taskArgs.severityThreshold = tl.getInput("severityThreshold", false);
   if (taskArgs.severityThreshold) {
@@ -162,7 +162,7 @@ async function runSnykTest(
     .argIf(taskArgs.dockerImageName, `--docker`)
     .argIf(taskArgs.dockerImageName, `${taskArgs.dockerImageName}`)
     .argIf(fileArg, `--file=${fileArg}`)
-    .argIf(taskArgs.additionalArguments, taskArgs.additionalArguments)
+    .line(taskArgs.additionalArguments)
     .arg(`--json`);
 
   let options = getOptionsToExecuteCmd(taskArgs);
@@ -255,7 +255,7 @@ async function runSnykMonitor(
     .argIf(fileArg, `--file=${fileArg}`)
     .argIf(taskArgs.organization, `--org=${taskArgs.organization}`)
     .argIf(taskArgs.projectName, `--project-name=${taskArgs.projectName}`)
-    .argIf(taskArgs.additionalArguments, taskArgs.additionalArguments);
+    .line(taskArgs.additionalArguments);
 
   const snykMonitorExitCode = await snykMonitorToolRunner.exec(options);
 

--- a/snykTask/src/task-args.ts
+++ b/snykTask/src/task-args.ts
@@ -16,7 +16,7 @@ class TaskArgs {
   projectName: string | undefined = "";
 
   testDirectory: string | undefined = "";
-  additionalArguments: string | undefined = "";
+  additionalArguments: string = "";
 
   getFileParameter() {
     if (this.targetFile && !this.dockerImageName) {


### PR DESCRIPTION
Replaces call to `argIf` with `line` to pass additional arguments.
Patches the task-args to force additionalArguments to string
Defaults additional arguments to "".