### PR TITLE
fix: add analytics environment variables to snyk CLI execs

### DIFF
--- a/snykTask/src/__tests__/task-lib.test.ts
+++ b/snykTask/src/__tests__/task-lib.test.ts
@@ -1,0 +1,84 @@
+import * as tr from "azure-pipelines-task-lib/toolrunner";
+import stream = require("stream");
+
+import {
+  getOptionsToExecuteSnykCLICommand,
+  getOptionsToExecuteCmd,
+  getOptionsToWriteFile
+} from "../task-lib";
+import { TaskArgs } from "../task-args";
+
+test("getOptionsToExecuteSnyk builds IExecOptions like we need it", () => {
+  const taskArgs: TaskArgs = new TaskArgs();
+  taskArgs.testDirectory = "/some/path";
+
+  const options: tr.IExecOptions = getOptionsToExecuteCmd(taskArgs);
+
+  expect(options.cwd).toBe("/some/path");
+  expect(options.failOnStdErr).toBe(false);
+  expect(options.ignoreReturnCode).toBe(true);
+});
+
+test("getOptionsToExecuteSnykCLICommand builds IExecOptions like we need it", () => {
+  const taskNameForAnalytics = "snyk-azure-pipelines-task";
+  const version = "1.2.3";
+
+  const taskArgs: TaskArgs = new TaskArgs();
+  taskArgs.testDirectory = "/some/path";
+
+  const options: tr.IExecOptions = getOptionsToExecuteSnykCLICommand(
+    taskArgs,
+    taskNameForAnalytics,
+    version
+  );
+
+  expect(options.cwd).toBe("/some/path");
+  expect(options.failOnStdErr).toBe(false);
+  expect(options.ignoreReturnCode).toBe(true);
+  expect(options.env?.SNYK_INTEGRATION_NAME).toBe("snyk-azure-pipelines-task");
+  expect(options.env?.SNYK_INTEGRATION_VERSION).toBe(version);
+});
+
+test("getOptionsToWriteFile builds IExecOptions like we need it", () => {
+  const outputFilePath = "./test-output-file.discardable";
+  const testDirectory = process.cwd();
+
+  const taskArgs: TaskArgs = new TaskArgs();
+  taskArgs.testDirectory = "/some/path";
+
+  const options: tr.IExecOptions = getOptionsToWriteFile(
+    outputFilePath,
+    testDirectory,
+    taskArgs
+  );
+
+  expect(options.cwd).toBe("/some/path");
+  expect(options.failOnStdErr).toBe(false);
+  expect(options.ignoreReturnCode).toBe(true);
+  expect(options.outStream).toBeInstanceOf(stream.Writable);
+});
+
+test("getOptionsToWriteFile builds IExecOptions like we need it for snyk test", () => {
+  const outputFilePath = "./test-output-file.discardable";
+  const testDirectory = process.cwd();
+  const taskNameForAnalytics = "snyk-azure-pipelines-task";
+  const version = "1.2.3";
+
+  const taskArgs: TaskArgs = new TaskArgs();
+  taskArgs.testDirectory = "/some/path";
+
+  const options: tr.IExecOptions = getOptionsToWriteFile(
+    outputFilePath,
+    testDirectory,
+    taskArgs,
+    taskNameForAnalytics,
+    version
+  );
+
+  expect(options.cwd).toBe("/some/path");
+  expect(options.failOnStdErr).toBe(false);
+  expect(options.ignoreReturnCode).toBe(true);
+  expect(options.outStream).toBeInstanceOf(stream.Writable);
+  expect(options.env?.SNYK_INTEGRATION_NAME).toBe("snyk-azure-pipelines-task");
+  expect(options.env?.SNYK_INTEGRATION_VERSION).toBe(version);
+});

--- a/snykTask/src/__tests__/task-version.test.ts
+++ b/snykTask/src/__tests__/task-version.test.ts
@@ -1,0 +1,28 @@
+test("ensure we can read the version from the task.json file", () => {
+  const mockFn = jest.fn().mockReturnValue(`{
+        "id": "some-id",
+        "name": "SnykSecurityScan",
+        "friendlyName": "Snyk Security Scan",
+        "description": "Azure Pipelines Task for Snyk",
+        "helpMarkDown": "",
+        "category": "Utility",
+        "author": "Snyk",
+        "version": {
+          "Major": 1,
+          "Minor": 2,
+          "Patch": 3
+        },
+        "instanceNameFormat": "Snyk scan for open source vulnerabilities"
+    }`);
+
+  jest.doMock("fs", () => {
+    return {
+      readFileSync: mockFn
+    };
+  });
+
+  const taskVersionModule = require("../task-version");
+  const v: string = taskVersionModule.getTaskVersion("./snykTask/task.json");
+  expect(v).toBe("1.2.3");
+  expect(mockFn).toHaveBeenCalledTimes(1);
+});

--- a/snykTask/src/task-lib.ts
+++ b/snykTask/src/task-lib.ts
@@ -1,0 +1,58 @@
+import { TaskArgs } from "./task-args";
+import * as tr from "azure-pipelines-task-lib/toolrunner";
+import stream = require("stream");
+import * as fs from "fs";
+
+export const getOptionsToExecuteCmd = (taskArgs: TaskArgs): tr.IExecOptions => {
+  return {
+    cwd: taskArgs.testDirectory,
+    failOnStdErr: false,
+    ignoreReturnCode: true
+  } as tr.IExecOptions;
+};
+
+export const getOptionsToExecuteSnykCLICommand = (
+  taskArgs: TaskArgs,
+  taskNameForAnalytics: string,
+  taskVersion: string
+): tr.IExecOptions => {
+  const envVars = process.env;
+  envVars["SNYK_INTEGRATION_NAME"] = taskNameForAnalytics;
+  envVars["SNYK_INTEGRATION_VERSION"] = taskVersion;
+
+  const options = {
+    cwd: taskArgs.testDirectory,
+    failOnStdErr: false,
+    ignoreReturnCode: true,
+    env: envVars
+  } as tr.IExecOptions;
+
+  return options;
+};
+
+export const getOptionsToWriteFile = (
+  file: string,
+  workDir: string,
+  taskArgs: TaskArgs,
+  taskNameForAnalytics?: string,
+  taskVersion?: string
+): tr.IExecOptions => {
+  const jsonFilePath = `${workDir}/${file}`;
+  const writableString: stream.Writable = fs.createWriteStream(jsonFilePath);
+
+  const envVars = process.env;
+  if (taskNameForAnalytics) {
+    envVars["SNYK_INTEGRATION_NAME"] = taskNameForAnalytics;
+  }
+  if (taskVersion) {
+    envVars["SNYK_INTEGRATION_VERSION"] = taskVersion;
+  }
+
+  return {
+    cwd: taskArgs.testDirectory,
+    failOnStdErr: false,
+    ignoreReturnCode: true,
+    outStream: writableString,
+    env: envVars
+  } as tr.IExecOptions;
+};

--- a/snykTask/src/task-version.ts
+++ b/snykTask/src/task-version.ts
@@ -1,0 +1,10 @@
+import * as fs from "fs";
+
+export function getTaskVersion(taskJsonPath: string): string {
+  const taskJsonFile = fs.readFileSync(taskJsonPath, "utf8");
+  const taskObj = JSON.parse(taskJsonFile);
+  const versionObj = taskObj.version;
+
+  const versionString = `${versionObj.Major}.${versionObj.Minor}.${versionObj.Patch}`;
+  return versionString;
+}


### PR DESCRIPTION
This PR corresponds to the change to the CLI which will capture the SNYK_INTEGRATION_NAME and SNYK_INTEGRATION_VERSION environment variables (if set) for analytics purposes (https://github.com/snyk/snyk/pull/1068).

- extracted getOptionsToExecuteCmd and getOptionsToWriteFile into task-lib.ts
- added getOptionsToExecuteSnykCLICommand to add SNYK_INTEGRATION_NAME and SNYK_INTEGRATION_VERSION environment variables
- added tests for getOptionsToExecuteCmd, getOptionsToWriteFile, and getOptionsToExecuteSnykCLICommand
- added task-version to extract detect the current task version and corresponding test