### PR TITLE
Show snyk test ouptut in CI logs while still generating the report from JSON

### DIFF
--- a/snykTask/src/__tests__/_test-mock-config-basic-smoke-test-docker.ts
+++ b/snykTask/src/__tests__/_test-mock-config-basic-smoke-test-docker.ts
@@ -48,7 +48,7 @@ const answers: ma.TaskLibAnswers = {
       code: 0,
       stdout: "Snyk CLI authorized!"
     },
-    "/usr/bin/snyk test --docker myImage --file=Dockerfile --someAdditionalArgs --json": {
+    "/usr/bin/snyk test --docker myImage --file=Dockerfile --someAdditionalArgs --json-file-output=report.json": {
       code: 0,
       stdout: "No issues found"
     },

--- a/snykTask/src/__tests__/_test-mock-config-basic-smoke-test.ts
+++ b/snykTask/src/__tests__/_test-mock-config-basic-smoke-test.ts
@@ -50,6 +50,10 @@ const answers: ma.TaskLibAnswers = {
       code: 0,
       stdout: "No issues found"
     },
+    "/usr/bin/snyk test --someAdditionalArgs --json-file-output=report.json": {
+      code: 0,
+      stdout: "No issues found"
+    },
     "/usr/bin/snyk-to-html -i null/report.json": {
       code: 0,
       stdout: "No issues found"

--- a/snykTask/src/__tests__/_test-mock-config-monitorOnBuild-false.ts
+++ b/snykTask/src/__tests__/_test-mock-config-monitorOnBuild-false.ts
@@ -46,7 +46,7 @@ const answers: ma.TaskLibAnswers = {
       code: 0,
       stdout: "Snyk CLI authorized!"
     },
-    "/usr/bin/snyk test --json": {
+    "/usr/bin/snyk test --json-file-output=report.json": {
       code: 0,
       stdout: "No issues found"
     },

--- a/snykTask/src/__tests__/_test-mock-config-no-fail-task-if-snyk-finds-issues-but-failOnIssues-is-false.ts
+++ b/snykTask/src/__tests__/_test-mock-config-no-fail-task-if-snyk-finds-issues-but-failOnIssues-is-false.ts
@@ -44,7 +44,7 @@ const answers: ma.TaskLibAnswers = {
       code: 0,
       stdout: "Snyk CLI authorized!"
     },
-    "/usr/bin/snyk test --json": {
+    "/usr/bin/snyk test --json-file-output=report.json": {
       code: 1,
       stdout: "Issues found"
     },

--- a/snykTask/src/__tests__/_test-mock-config-no-fail-task-if-snyk-finds-issues-but-failOnIssues-is-true.ts
+++ b/snykTask/src/__tests__/_test-mock-config-no-fail-task-if-snyk-finds-issues-but-failOnIssues-is-true.ts
@@ -44,7 +44,7 @@ const answers: ma.TaskLibAnswers = {
       code: 0,
       stdout: "Snyk CLI authorized!"
     },
-    "/usr/bin/snyk test --json": {
+    "/usr/bin/snyk test --json-file-output=report.json": {
       code: 1,
       stdout: "Issues found"
     },

--- a/snykTask/src/__tests__/_test-mock-config-no-organization.ts
+++ b/snykTask/src/__tests__/_test-mock-config-no-organization.ts
@@ -48,7 +48,7 @@ const answers: ma.TaskLibAnswers = {
       code: 0,
       stdout: "Snyk CLI authorized!"
     },
-    "/usr/bin/snyk test --json": {
+    "/usr/bin/snyk test --json-file-output=report.json": {
       code: 0,
       stdout: "No issues found"
     },

--- a/snykTask/src/__tests__/_test-mock-config-no-projectName.ts
+++ b/snykTask/src/__tests__/_test-mock-config-no-projectName.ts
@@ -47,7 +47,7 @@ const answers: ma.TaskLibAnswers = {
       code: 0,
       stdout: "Snyk CLI authorized!"
     },
-    "/usr/bin/snyk test --json": {
+    "/usr/bin/snyk test --json-file-output=report.json": {
       code: 0,
       stdout: "No issues found"
     },

--- a/snykTask/src/__tests__/_test-mock-config-no-snyk-monitor-if-snyk-test-fails.ts
+++ b/snykTask/src/__tests__/_test-mock-config-no-snyk-monitor-if-snyk-test-fails.ts
@@ -47,7 +47,7 @@ const answers: ma.TaskLibAnswers = {
       code: 0,
       stdout: "Snyk CLI authorized!"
     },
-    "/usr/bin/snyk test --json": {
+    "/usr/bin/snyk test --json-file-output=report.json": {
       code: 1,
       stdout: "Issues found"
     },

--- a/snykTask/src/__tests__/_test-mock-config-snyk-monitor-fails-because-unknown-error.ts
+++ b/snykTask/src/__tests__/_test-mock-config-snyk-monitor-fails-because-unknown-error.ts
@@ -46,7 +46,7 @@ const answers: ma.TaskLibAnswers = {
       code: 0,
       stdout: "Snyk CLI authorized!"
     },
-    "/usr/bin/snyk test --json": {
+    "/usr/bin/snyk test --json-file-output=report.json": {
       code: 0,
       stdout: "Ok"
     },

--- a/snykTask/src/__tests__/_test-mock-config-snyk-monitor-fails-because-unknown-file.ts
+++ b/snykTask/src/__tests__/_test-mock-config-snyk-monitor-fails-because-unknown-file.ts
@@ -46,7 +46,7 @@ const answers: ma.TaskLibAnswers = {
       code: 0,
       stdout: "Snyk CLI authorized!"
     },
-    "/usr/bin/snyk test --json": {
+    "/usr/bin/snyk test --json-file-output=report.json": {
       code: 0,
       stdout: "Ok"
     },

--- a/snykTask/src/__tests__/_test-mock-config-snyk-test-fails-for-reasons-other-than-issues-found.ts
+++ b/snykTask/src/__tests__/_test-mock-config-snyk-test-fails-for-reasons-other-than-issues-found.ts
@@ -46,7 +46,7 @@ const answers: ma.TaskLibAnswers = {
       code: 0,
       stdout: "Snyk CLI authorized!"
     },
-    "/usr/bin/snyk test --json": {
+    "/usr/bin/snyk test --json-file-output=report.json": {
       code: 2,
       stdout: "Ok"
     },

--- a/snykTask/src/__tests__/_test-mock-config-use-targetFile-if-specified.ts
+++ b/snykTask/src/__tests__/_test-mock-config-use-targetFile-if-specified.ts
@@ -45,7 +45,7 @@ const answers: ma.TaskLibAnswers = {
       code: 0,
       stdout: "Snyk CLI authorized!"
     },
-    "/usr/bin/snyk test --file=some/dir/pom.xml --json": {
+    "/usr/bin/snyk test --file=some/dir/pom.xml --json-file-output=report.json": {
       code: 0,
       stdout: "Ok"
     },

--- a/snykTask/src/__tests__/_test-mock-config-with-null-additionalArguments.ts
+++ b/snykTask/src/__tests__/_test-mock-config-with-null-additionalArguments.ts
@@ -43,7 +43,7 @@ const answers: ma.TaskLibAnswers = {
       code: 0,
       stdout: "Snyk CLI authorized!"
     },
-    "/usr/bin/snyk test --json": {
+    "/usr/bin/snyk test --json-file-output=report.json": {
       code: 0,
       stdout: "Ok"
     },

--- a/snykTask/src/__tests__/_test-mock-config-with-null-severityThreshold.ts
+++ b/snykTask/src/__tests__/_test-mock-config-with-null-severityThreshold.ts
@@ -43,7 +43,7 @@ const answers: ma.TaskLibAnswers = {
       code: 0,
       stdout: "Snyk CLI authorized!"
     },
-    "/usr/bin/snyk test --json": {
+    "/usr/bin/snyk test --json-file-output=report.json": {
       code: 0,
       stdout: "Ok"
     },

--- a/snykTask/src/__tests__/_test-mock-config-with-severityThreshold.ts
+++ b/snykTask/src/__tests__/_test-mock-config-with-severityThreshold.ts
@@ -44,7 +44,7 @@ const answers: ma.TaskLibAnswers = {
       code: 0,
       stdout: "Snyk CLI authorized!"
     },
-    "/usr/bin/snyk test --severity-threshold=high --json": {
+    "/usr/bin/snyk test --severity-threshold=high --json-file-output=report.json": {
       code: 0,
       stdout: "Ok"
     },

--- a/snykTask/src/__tests__/test-task.ts
+++ b/snykTask/src/__tests__/test-task.ts
@@ -37,7 +37,9 @@ test("basic smoke test - inputs are ok", () => {
     true
   );
   expect(
-    mockTestRunner.cmdlines["/usr/bin/snyk test --someAdditionalArgs --json"]
+    mockTestRunner.cmdlines[
+      "/usr/bin/snyk test --someAdditionalArgs --json-file-output=report.json"
+    ]
   ).toBe(true);
   expect(
     mockTestRunner.cmdlines["/usr/bin/snyk-to-html -i null/report.json"]
@@ -68,7 +70,7 @@ test("basic smoke test for container test - inputs are ok", () => {
   );
   expect(
     mockTestRunner.cmdlines[
-      "/usr/bin/snyk test --docker myImage --file=Dockerfile --someAdditionalArgs --json"
+      "/usr/bin/snyk test --docker myImage --file=Dockerfile --someAdditionalArgs --json-file-output=report.json"
     ]
   ).toBe(true);
   expect(
@@ -131,7 +133,7 @@ test("doesn't fail if severityThreshold is specified", () => {
 
   expect(
     testMockRunner.cmdlines[
-      "/usr/bin/snyk test --severity-threshold=high --json"
+      "/usr/bin/snyk test --severity-threshold=high --json-file-output=report.json"
     ]
   ).toBe(true);
   expect(testMockRunner.succeeded).toBe(true); // 'should have succeeded'
@@ -342,7 +344,9 @@ test("test that if you set targetFile that we use it ", () => {
   mockTestRunner.run();
 
   expect(
-    mockTestRunner.cmdlines["/usr/bin/snyk test --file=some/dir/pom.xml --json"]
+    mockTestRunner.cmdlines[
+      "/usr/bin/snyk test --file=some/dir/pom.xml --json-file-output=report.json"
+    ]
   ).toBe(true);
   expect(
     mockTestRunner.cmdlines[

--- a/snykTask/src/index.ts
+++ b/snykTask/src/index.ts
@@ -182,24 +182,13 @@ async function runSnykTest(
     .argIf(taskArgs.dockerImageName, `${taskArgs.dockerImageName}`)
     .argIf(fileArg, `--file=${fileArg}`)
     .line(taskArgs.additionalArguments)
-    .arg(`--json`);
+    .arg(`--json-file-output=${fileName}`);
 
-  let options = getOptionsToExecuteSnykCLICommand(
+  const options = getOptionsToExecuteSnykCLICommand(
     taskArgs,
     taskNameForAnalytics,
     taskVersion
   );
-
-  if (fs.existsSync(workDir)) {
-    console.log("Set Execute Snyk Test with file out stream");
-    options = getOptionsToWriteFile(
-      fileName,
-      workDir,
-      taskArgs,
-      taskNameForAnalytics,
-      taskVersion
-    );
-  }
 
   const command = `[command]${getToolPath("snyk", tl.which)} snyk test...`;
   console.log(command);


### PR DESCRIPTION
Rather than using `--json` to send JSON to stdout and redirecting that to a file and generate the HTML report from that, this PR makes it so that we generate the required JSON output using the new `--json-file-output` option in the CLI (https://github.com/snyk/snyk/pull/1107) to generate the JSON while allowing the usual human-readable output from `snyk test` to go the CI logs.
