### PR TITLE
Use Agent.TempDirectory folder for report files

### DIFF
--- a/snykTask/src/__tests__/_test-mock-config-basic-smoke-test-docker.ts
+++ b/snykTask/src/__tests__/_test-mock-config-basic-smoke-test-docker.ts
@@ -52,7 +52,7 @@ const answers: ma.TaskLibAnswers = {
       code: 0,
       stdout: "No issues found"
     },
-    "/usr/bin/snyk-to-html -i null/report.json": {
+    "/usr/bin/snyk-to-html -i report.json": {
       code: 0,
       stdout: "No issues found"
     },

--- a/snykTask/src/__tests__/_test-mock-config-basic-smoke-test.ts
+++ b/snykTask/src/__tests__/_test-mock-config-basic-smoke-test.ts
@@ -54,7 +54,7 @@ const answers: ma.TaskLibAnswers = {
       code: 0,
       stdout: "No issues found"
     },
-    "/usr/bin/snyk-to-html -i null/report.json": {
+    "/usr/bin/snyk-to-html -i report.json": {
       code: 0,
       stdout: "No issues found"
     },

--- a/snykTask/src/__tests__/_test-mock-config-monitorOnBuild-false.ts
+++ b/snykTask/src/__tests__/_test-mock-config-monitorOnBuild-false.ts
@@ -50,7 +50,7 @@ const answers: ma.TaskLibAnswers = {
       code: 0,
       stdout: "No issues found"
     },
-    "/usr/bin/snyk-to-html -i null/report.json": {
+    "/usr/bin/snyk-to-html -i report.json": {
       code: 0,
       stdout: "No issues found"
     },

--- a/snykTask/src/__tests__/_test-mock-config-no-auth-token.ts
+++ b/snykTask/src/__tests__/_test-mock-config-no-auth-token.ts
@@ -52,7 +52,7 @@ const answers: ma.TaskLibAnswers = {
       code: 0,
       stdout: "No issues found"
     },
-    "/usr/bin/sudo snyk-to-html -i null/report.json": {
+    "/usr/bin/sudo snyk-to-html -i report.json": {
       code: 0,
       stdout: "No issues found"
     },

--- a/snykTask/src/__tests__/_test-mock-config-no-fail-task-if-snyk-finds-issues-but-failOnIssues-is-false.ts
+++ b/snykTask/src/__tests__/_test-mock-config-no-fail-task-if-snyk-finds-issues-but-failOnIssues-is-false.ts
@@ -48,7 +48,7 @@ const answers: ma.TaskLibAnswers = {
       code: 1,
       stdout: "Issues found"
     },
-    "/usr/bin/snyk-to-html -i null/report.json": {
+    "/usr/bin/snyk-to-html -i report.json": {
       code: 0,
       stdout: "No issues found"
     },

--- a/snykTask/src/__tests__/_test-mock-config-no-fail-task-if-snyk-finds-issues-but-failOnIssues-is-true.ts
+++ b/snykTask/src/__tests__/_test-mock-config-no-fail-task-if-snyk-finds-issues-but-failOnIssues-is-true.ts
@@ -48,7 +48,7 @@ const answers: ma.TaskLibAnswers = {
       code: 1,
       stdout: "Issues found"
     },
-    "/usr/bin/snyk-to-html -i null/report.json": {
+    "/usr/bin/snyk-to-html -i report.json": {
       code: 0,
       stdout: "No issues found"
     },

--- a/snykTask/src/__tests__/_test-mock-config-no-organization.ts
+++ b/snykTask/src/__tests__/_test-mock-config-no-organization.ts
@@ -52,7 +52,7 @@ const answers: ma.TaskLibAnswers = {
       code: 0,
       stdout: "No issues found"
     },
-    "/usr/bin/snyk-to-html -i null/report.json": {
+    "/usr/bin/snyk-to-html -i report.json": {
       code: 0,
       stdout: "No issues found"
     },

--- a/snykTask/src/__tests__/_test-mock-config-no-projectName.ts
+++ b/snykTask/src/__tests__/_test-mock-config-no-projectName.ts
@@ -51,7 +51,7 @@ const answers: ma.TaskLibAnswers = {
       code: 0,
       stdout: "No issues found"
     },
-    "/usr/bin/snyk-to-html -i null/report.json": {
+    "/usr/bin/snyk-to-html -i report.json": {
       code: 0,
       stdout: "No issues found"
     },

--- a/snykTask/src/__tests__/_test-mock-config-no-snyk-monitor-if-snyk-test-fails.ts
+++ b/snykTask/src/__tests__/_test-mock-config-no-snyk-monitor-if-snyk-test-fails.ts
@@ -51,7 +51,7 @@ const answers: ma.TaskLibAnswers = {
       code: 1,
       stdout: "Issues found"
     },
-    "/usr/bin/snyk-to-html -i null/report.json": {
+    "/usr/bin/snyk-to-html -i report.json": {
       code: 0,
       stdout: "No issues found"
     },

--- a/snykTask/src/__tests__/_test-mock-config-snyk-monitor-fails-because-unknown-error.ts
+++ b/snykTask/src/__tests__/_test-mock-config-snyk-monitor-fails-because-unknown-error.ts
@@ -50,7 +50,7 @@ const answers: ma.TaskLibAnswers = {
       code: 0,
       stdout: "Ok"
     },
-    "/usr/bin/snyk-to-html -i null/report.json": {
+    "/usr/bin/snyk-to-html -i report.json": {
       code: 0,
       stdout: "No issues found"
     },

--- a/snykTask/src/__tests__/_test-mock-config-snyk-monitor-fails-because-unknown-file.ts
+++ b/snykTask/src/__tests__/_test-mock-config-snyk-monitor-fails-because-unknown-file.ts
@@ -50,7 +50,7 @@ const answers: ma.TaskLibAnswers = {
       code: 0,
       stdout: "Ok"
     },
-    "/usr/bin/snyk-to-html -i null/report.json": {
+    "/usr/bin/snyk-to-html -i report.json": {
       code: 0,
       stdout: "No issues found"
     },

--- a/snykTask/src/__tests__/_test-mock-config-snyk-test-fails-for-reasons-other-than-issues-found.ts
+++ b/snykTask/src/__tests__/_test-mock-config-snyk-test-fails-for-reasons-other-than-issues-found.ts
@@ -50,7 +50,7 @@ const answers: ma.TaskLibAnswers = {
       code: 2,
       stdout: "Ok"
     },
-    "/usr/bin/snyk-to-html -i null/report.json": {
+    "/usr/bin/snyk-to-html -i report.json": {
       code: 0,
       stdout: "No issues found"
     },

--- a/snykTask/src/__tests__/_test-mock-config-use-targetFile-if-specified.ts
+++ b/snykTask/src/__tests__/_test-mock-config-use-targetFile-if-specified.ts
@@ -49,7 +49,7 @@ const answers: ma.TaskLibAnswers = {
       code: 0,
       stdout: "Ok"
     },
-    "/usr/bin/snyk-to-html -i null/report.json": {
+    "/usr/bin/snyk-to-html -i report.json": {
       code: 0,
       stdout: "No issues found"
     },

--- a/snykTask/src/__tests__/_test-mock-config-with-invalid-severityThreshold.ts
+++ b/snykTask/src/__tests__/_test-mock-config-with-invalid-severityThreshold.ts
@@ -48,7 +48,7 @@ const answers: ma.TaskLibAnswers = {
       code: 0,
       stdout: "Ok"
     },
-    "/usr/bin/sudo snyk-to-html -i null/report.json": {
+    "/usr/bin/sudo snyk-to-html -i report.json": {
       code: 0,
       stdout: "No issues found"
     },

--- a/snykTask/src/__tests__/_test-mock-config-with-null-additionalArguments.ts
+++ b/snykTask/src/__tests__/_test-mock-config-with-null-additionalArguments.ts
@@ -47,7 +47,7 @@ const answers: ma.TaskLibAnswers = {
       code: 0,
       stdout: "Ok"
     },
-    "/usr/bin/snyk-to-html -i null/report.json": {
+    "/usr/bin/snyk-to-html -i report.json": {
       code: 0,
       stdout: "No issues found"
     },

--- a/snykTask/src/__tests__/_test-mock-config-with-null-severityThreshold.ts
+++ b/snykTask/src/__tests__/_test-mock-config-with-null-severityThreshold.ts
@@ -47,7 +47,7 @@ const answers: ma.TaskLibAnswers = {
       code: 0,
       stdout: "Ok"
     },
-    "/usr/bin/snyk-to-html -i null/report.json": {
+    "/usr/bin/snyk-to-html -i report.json": {
       code: 0,
       stdout: "No issues found"
     },

--- a/snykTask/src/__tests__/_test-mock-config-with-severityThreshold.ts
+++ b/snykTask/src/__tests__/_test-mock-config-with-severityThreshold.ts
@@ -48,7 +48,7 @@ const answers: ma.TaskLibAnswers = {
       code: 0,
       stdout: "Ok"
     },
-    "/usr/bin/snyk-to-html -i null/report.json": {
+    "/usr/bin/snyk-to-html -i report.json": {
       code: 0,
       stdout: "No issues found"
     },

--- a/snykTask/src/__tests__/task-lib.test.ts
+++ b/snykTask/src/__tests__/task-lib.test.ts
@@ -1,14 +1,17 @@
 import * as tr from "azure-pipelines-task-lib/toolrunner";
 import * as tl from "azure-pipelines-task-lib/task";
+import * as fs from "fs";
 
 import stream = require("stream");
 
 import {
   getOptionsToExecuteSnykCLICommand,
   getOptionsToExecuteCmd,
-  getOptionsToWriteFile,
+  getOptionsForSnykToHtml,
   isSudoMode,
-  getToolPath
+  getToolPath,
+  formatDate,
+  attachReport
 } from "../task-lib";
 import { TaskArgs } from "../task-args";
 
@@ -43,16 +46,12 @@ test("getOptionsToExecuteSnykCLICommand builds IExecOptions like we need it", ()
   expect(options.env?.SNYK_INTEGRATION_VERSION).toBe(version);
 });
 
-test("getOptionsToWriteFile builds IExecOptions like we need it", () => {
-  const outputFilePath = "./test-output-file.discardable";
-  const testDirectory = process.cwd();
-
+test("getOptionsForSnykToHtml builds IExecOptions for running snyk-to-html", () => {
   const taskArgs: TaskArgs = new TaskArgs();
   taskArgs.testDirectory = "/some/path";
-
-  const options: tr.IExecOptions = getOptionsToWriteFile(
-    outputFilePath,
-    testDirectory,
+  const htmlReportFilePath = "report.html";
+  const options: tr.IExecOptions = getOptionsForSnykToHtml(
+    htmlReportFilePath,
     taskArgs
   );
 
@@ -60,31 +59,6 @@ test("getOptionsToWriteFile builds IExecOptions like we need it", () => {
   expect(options.failOnStdErr).toBe(false);
   expect(options.ignoreReturnCode).toBe(true);
   expect(options.outStream).toBeInstanceOf(stream.Writable);
-});
-
-test("getOptionsToWriteFile builds IExecOptions like we need it for snyk test", () => {
-  const outputFilePath = "./test-output-file.discardable";
-  const testDirectory = process.cwd();
-  const taskNameForAnalytics = "snyk-azure-pipelines-task";
-  const version = "1.2.3";
-
-  const taskArgs: TaskArgs = new TaskArgs();
-  taskArgs.testDirectory = "/some/path";
-
-  const options: tr.IExecOptions = getOptionsToWriteFile(
-    outputFilePath,
-    testDirectory,
-    taskArgs,
-    taskNameForAnalytics,
-    version
-  );
-
-  expect(options.cwd).toBe("/some/path");
-  expect(options.failOnStdErr).toBe(false);
-  expect(options.ignoreReturnCode).toBe(true);
-  expect(options.outStream).toBeInstanceOf(stream.Writable);
-  expect(options.env?.SNYK_INTEGRATION_NAME).toBe("snyk-azure-pipelines-task");
-  expect(options.env?.SNYK_INTEGRATION_VERSION).toBe(version);
 });
 
 test("isSudoMode returns true only for Linux platforms", () => {
@@ -117,4 +91,31 @@ test("getToolPath returns sudo if require and not if not required", () => {
   expect(getToolPath("some-command", mockTlWhichFn, true)).toBe(
     "/usr/bin/sudo"
   );
+});
+
+test("formatDate gives format we want for the report filename", () => {
+  const timestampMillis = 1590174610000; // arbitrary timestamp in ms since epoch
+  const d = new Date(timestampMillis);
+  const timestamp = formatDate(d);
+  expect(timestamp).toBe("2020-05-22T19-10-10");
+});
+
+test("attachReport works", () => {
+  const filePath = "/path/to/report.html";
+  const fsExistsSyncSpy = jest.spyOn(fs, "existsSync").mockReturnValue(true);
+  const addAttachmentSpy = jest
+    .spyOn(tl, "addAttachment")
+    .mockReturnValue(undefined);
+
+  attachReport(filePath, "HTML_ATTACHMENT_TYPE");
+  expect(addAttachmentSpy).toHaveBeenCalledTimes(1);
+  expect(addAttachmentSpy).toHaveBeenNthCalledWith(
+    1,
+    "HTML_ATTACHMENT_TYPE",
+    "report.html",
+    filePath
+  );
+
+  fsExistsSyncSpy.mockRestore();
+  addAttachmentSpy.mockRestore();
 });

--- a/snykTask/src/__tests__/test-task.ts
+++ b/snykTask/src/__tests__/test-task.ts
@@ -41,9 +41,9 @@ test("basic smoke test - inputs are ok", () => {
       "/usr/bin/snyk test --someAdditionalArgs --json-file-output=report.json"
     ]
   ).toBe(true);
-  expect(
-    mockTestRunner.cmdlines["/usr/bin/snyk-to-html -i null/report.json"]
-  ).toBe(true);
+  expect(mockTestRunner.cmdlines["/usr/bin/snyk-to-html -i report.json"]).toBe(
+    true
+  );
   expect(
     mockTestRunner.cmdlines[
       "/usr/bin/snyk monitor --org=some-snyk-org --project-name=some-projectName --someAdditionalArgs"
@@ -73,9 +73,9 @@ test("basic smoke test for container test - inputs are ok", () => {
       "/usr/bin/snyk test --docker myImage --file=Dockerfile --someAdditionalArgs --json-file-output=report.json"
     ]
   ).toBe(true);
-  expect(
-    mockTestRunner.cmdlines["/usr/bin/snyk-to-html -i null/report.json"]
-  ).toBe(true);
+  expect(mockTestRunner.cmdlines["/usr/bin/snyk-to-html -i report.json"]).toBe(
+    true
+  );
   expect(
     mockTestRunner.cmdlines[
       "/usr/bin/snyk monitor --docker myImage --file=Dockerfile --org=some-snyk-org --project-name=some-projectName --someAdditionalArgs"
@@ -171,10 +171,6 @@ test("fails if severityThreshold is invalid", () => {
   testMockRunner.run();
 
   expect(testMockRunner.succeeded).toBe(false); // 'should have succeeded'
-  console.log("warnings:");
-  console.log(testMockRunner.warningIssues);
-  console.log("errors:");
-  console.log(testMockRunner.errorIssues);
   expect(testMockRunner.warningIssues.length).toBe(0); // "should have no warnings");
   expect(testMockRunner.errorIssues.length).toBe(1); // "should have no errors");
   expect(testMockRunner.errorIssues[0]).toBe(


### PR DESCRIPTION
- [x] Ready for review 

Use the temp folder given by the `Agent.TempDirectory` variable to control where we output the report json / html files.

Relates to:
- https://github.com/snyk/snyk-azure-pipelines-task/issues/54
- https://github.com/snyk/snyk/issues/1168
- HAMMER-71
