### PR TITLE
fix: only show snyk report tab if using snyk task

### DIFF
--- a/vss-extension.json
+++ b/vss-extension.json
@@ -79,7 +79,10 @@
       ],
       "properties": {
         "name": "Snyk Report",
-        "uri": "ui/snyk-report-tab.html"
+		"uri": "ui/snyk-report-tab.html",
+		"supportsTasks": ["826d5fe9-3983-4643-b918-487964d7cc87", "97c57f20-5370-4b19-a76b-fc925e625ed7"],
+		"supportsMobile": false,
+		"dynamic": true
       }
     },
 		{


### PR DESCRIPTION
Only show the snyk report tab if the snyk task is in a pipeline.
Addresses https://github.com/snyk/snyk-azure-pipelines-task/issues/62