### PR TITLE
fix: set license to Apache-2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,14 @@
+Copyright 2020 Snyk Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     ]
   },
   "author": "snyk.io",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "dependencies": {
     "azure-pipelines-task-lib": "2.9.3",
     "jquery": "^3.4.1",


### PR DESCRIPTION
Add Apache-2.0 LICENSE file and set license field in package.json to `Apache-2.0`