### PR TITLE
Upgrade version of jest and ts-jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,13 +68,13 @@
     "eslint-config-prettier": "^6.1.0",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jest": "^22.15.2",
-    "jest": "^24.9.0",
+    "jest": "^26.4.2",
     "mock-fs": "^4.10.4",
     "prettier": "^1.18.2",
     "semantic-release": "^17.0.4",
     "sync-request": "^6.1.0",
     "tfx-cli": "^0.7.11",
-    "ts-jest": "^24.0.2",
+    "ts-jest": "^26.3.0",
     "typescript": "^3.5.3"
   }
 }


### PR DESCRIPTION
Upgrade:
- `ts-jest@24.0.2` -> `ts-jest@26.3.0`
- `jest@24.9.0` -> `jest@26.4.2`

to vulnerable transitive dependency:

❯ snyk test ts-jest@24.0.2
Testing ts-jest@24.0.2...

✗ Medium severity vulnerability found in yargs-parser
  Description: Prototype Pollution
  Info: https://snyk.io/vuln/SNYK-JS-YARGSPARSER-560381
  Introduced through: yargs-parser@10.1.0
  From: yargs-parser@10.1.0
