### PR TITLE
Upgrade azure-pipelines-task-lib dep

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,12 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Show Node Environment
+          command: |
+            node -v
+            npm -v
+            npx -v
+      - run:
           name: Build
           command: |
             ./scripts/ci-build.sh

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+**/node_modules/**

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "author": "snyk.io",
   "license": "Apache-2.0",
   "dependencies": {
-    "azure-pipelines-task-lib": "2.9.3",
+    "azure-pipelines-task-lib": "2.9.6",
     "jquery": "^3.4.1",
     "replace-in-file": "^4.2.0",
     "request": "^2.88.0",

--- a/snykTask/package.json
+++ b/snykTask/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "azure-pipelines-task-lib": "2.9.3",
+    "azure-pipelines-task-lib": "2.9.6",
     "replace-in-file": "^4.2.0"
   }
 }


### PR DESCRIPTION
This PR:
- Upgrade azure-pipelines-task-lib dep from `2.9.3` to `2.10.0`
- Add a `.eslintignore` file and add `**/node_modules**` because otherwise we had a lint issue with some downstream package because of upgrading to `azure-pipelines-task-lib@2.10.0`
