### PR TITLE
Add test pipeline for .NET Framework on Windows

### DIFF
--- a/ops/deploy/test-builds.json
+++ b/ops/deploy/test-builds.json
@@ -14,5 +14,10 @@
     {
         "projectName": "snyk-6598",
         "buildDefinitionId": 18
+    },
+    {
+        "projectName": "DotNetFrameworkSampleCLIApp",
+        "buildDefinitionId": 19
     }
 ]
+


### PR DESCRIPTION
Add test pipeline for .NET Framework on Windows. This is a classic .NET Framework (as opposed to .NET Core) project - i.e. the type that only runs on Windows - with more than one sub-projects.