### PR TITLE
UI handling for array of projects

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
     "roots": [
-        "<rootDir>/snykTask/src/"
+        "<rootDir>/snykTask/src/",
+        "<rootDir>/ui/"
     ],
     "transform": {
         "^.+\\.tsx?$": "ts-jest"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "npm run test:checks && npm run test:unit",
     "test:checks": "npm run eslint && npm run format:check",
     "test:snyk": "npx snyk test",
-    "test:unit": "jest --detectOpenHandles",
+    "test:unit": "jest",
     "compile": "tsc -b snykTask/tsconfig.json",
     "eslint": "eslint --cache 'snykTask/{src,test,public/js/{!(build)}}/**/*.{js,ts}'",
     "format:check": "prettier --check 'snykTask/{src,test,public/js/{!(build)}}/**/*.{js,ts}'",

--- a/ui/enhancer/__tests__/snyk-report.test.ts
+++ b/ui/enhancer/__tests__/snyk-report.test.ts
@@ -1,0 +1,87 @@
+/*
+  Tread carefully
+  ===============
+
+  snyk-report.ts is importing (global) Azure dependencies that don't exists in this project
+  thus TS compilation may fail on them, making it impossible for Jest to mock them
+*/
+
+import { generateReportTitle } from '../generate-report-title';
+
+describe('SnykReportTab UI', () => {
+  describe('generateReportTitle', () => {
+    test('handling of single project without vulns', () => {
+      const jsonResults = {
+        packageManager: 'nuget',
+        uniqueCount: 0,
+      };
+      const title = generateReportTitle(
+        jsonResults,
+        'report-2021-04-27T13-44-14.json'
+      );
+      expect(title).toEqual(
+        'Snyk Test for nuget (report-2021-04-27 13:44:14) | No issues found'
+      );
+    });
+
+    test('handling of single project with vulns', () => {
+      const jsonResults = {
+        packageManager: 'npm',
+        uniqueCount: 3,
+      };
+      const title = generateReportTitle(
+        jsonResults,
+        'report-2021-04-27T13-44-14.json'
+      );
+      expect(title).toEqual(
+        'Snyk Test for npm (report-2021-04-27 13:44:14) | Found 3 issues'
+      );
+    });
+
+    test('handling of multiple projects with vulns', () => {
+      const jsonResults = [
+        {
+          packageManager: 'npm',
+          uniqueCount: 3,
+        },
+        {
+          packageManager: 'npm',
+          uniqueCount: 2,
+        },
+      ];
+      const title = generateReportTitle(
+        jsonResults,
+        'report-2021-04-27T13-44-14.json'
+      );
+      expect(title).toEqual('Tested 2 npm projects | Found 5 issues');
+    });
+
+    test('handling of multiple projects with vulns', () => {
+      const jsonResults = [
+        {
+          packageManager: 'ruby',
+          uniqueCount: 3,
+        },
+        {
+          packageManager: 'ruby',
+          uniqueCount: 1,
+        },
+        {
+          packageManager: 'yarn',
+          uniqueCount: 0,
+        },
+        {
+          packageManager: 'python',
+          uniqueCount: 0,
+        },
+      ];
+      const title = generateReportTitle(
+        jsonResults,
+        'report-2021-04-27T13-44-14.json'
+      );
+      expect(title).toEqual(
+        'Tested 4 ruby/yarn/python projects | Found 4 issues'
+      );
+    });
+  });
+});

--- a/ui/enhancer/detect-vulns.ts
+++ b/ui/enhancer/detect-vulns.ts
@@ -1,0 +1,11 @@
+export function detectVulns(jsonResults: object | any[]): boolean {
+  if (Array.isArray(jsonResults)) {
+    return jsonResults.some((result) => !!result.uniqueCount);
+  }
+
+  if (jsonResults['uniqueCount'] && jsonResults['uniqueCount'] > 0) {
+    return true;
+  }
+
+  return false;
+}

--- a/ui/enhancer/generate-report-title.ts
+++ b/ui/enhancer/generate-report-title.ts
@@ -1,0 +1,61 @@
+import { detectVulns } from './detect-vulns';
+
+export function generateReportTitle(
+  jsonResults: object | any[],
+  attachmentName: string // timestamp e.g., 'report-2021-04-27T13-44-14.json'
+): string {
+  const vulnsFound = detectVulns(jsonResults);
+
+  // --all-projects flag may return results in an array
+  if (Array.isArray(jsonResults)) {
+    const vulnsCount: number = jsonResults.reduce(
+      (issuesFound, result): number =>
+        result.uniqueCount ? issuesFound + result.uniqueCount : issuesFound,
+      0
+    );
+    const uniquePackageManagers = Array.from(
+      new Set(
+        jsonResults.map((result) => result.packageManager).filter(Boolean)
+      )
+    ).join('/');
+
+    let titleText = `Tested ${jsonResults.length} ${uniquePackageManagers} projects`;
+    if (vulnsFound) {
+      titleText += ` | Found ${vulnsCount} issue${vulnsCount === 1 ? '' : 's'}`;
+    } else {
+      titleText += ` | No issues found`;
+    }
+
+    return titleText;
+  }
+
+  // Single project scan results
+  let titleText = '';
+  if (jsonResults['docker'] && jsonResults['docker']['baseImage']) {
+    titleText = `Snyk Test for ${
+      jsonResults['docker']['baseImage']
+    } (${formatReportName(attachmentName)})`;
+  }
+
+  if (jsonResults['packageManager']) {
+    titleText = `Snyk Test for ${
+      jsonResults['packageManager']
+    } (${formatReportName(attachmentName)})`;
+  }
+
+  if (jsonResults['uniqueCount'] && jsonResults['uniqueCount'] > 0) {
+    titleText += ` | Found ${jsonResults['uniqueCount']} issues`;
+  } else {
+    titleText += ` | No issues found`;
+  }
+
+  return titleText;
+}
+
+function formatReportName(
+  name: string /* timestamp e.g., 'report-2021-04-27T13-44-14.json' */
+): string {
+  const reportName = name.split('.')[0];
+  const tmpName = reportName.split('T');
+  return `${tmpName[0]} ${tmpName[1].replace(/-/g, ':')}`;
+}

--- a/ui/enhancer/snyk-report.ts
+++ b/ui/enhancer/snyk-report.ts
@@ -1,153 +1,173 @@
-import Controls = require("VSS/Controls");
-import TFSBuildContracts = require("TFS/Build/Contracts");
-import TFSBuildExtensionContracts = require("TFS/Build/ExtensionContracts");
-import DTClient = require("TFS/DistributedTask/TaskRestClient");
+import * as Controls from 'VSS/Controls';
+import * as TFSBuildContracts from 'TFS/Build/Contracts';
+import * as TFSBuildExtensionContracts from 'TFS/Build/ExtensionContracts';
+import * as DTClient from 'TFS/DistributedTask/TaskRestClient';
+import { generateReportTitle } from './generate-report-title';
+import { detectVulns } from './detect-vulns';
 
-const BUILD_PHASE = "build";
-const HTML_ATTACHMENT_TYPE = "HTML_ATTACHMENT_TYPE";
-const JSON_ATTACHMENT_TYPE = "JSON_ATTACHMENT_TYPE";
+const BUILD_PHASE = 'build';
+const HTML_ATTACHMENT_TYPE = 'HTML_ATTACHMENT_TYPE';
+const JSON_ATTACHMENT_TYPE = 'JSON_ATTACHMENT_TYPE';
 
 export class SnykReportTab extends Controls.BaseControl {
-	private projectId: string = "";
-	private planId: string = "";
-	private taskClient;
-	private reportList: HTMLElement[] = [];
+  private projectId: string = '';
+  private planId: string = '';
+  private taskClient;
+  private reportList: HTMLElement[] = [];
 
-	constructor() {
-		super();
-	}
+  constructor() {
+    super();
+  }
 
-	public initialize = (): void => {
-		super.initialize();
-		// Get configuration that's shared between extension and the extension host
-		const sharedConfig: TFSBuildExtensionContracts.IBuildResultsViewExtensionConfig = VSS.getConfiguration();
-		const vsoContext = VSS.getWebContext();
-		if(sharedConfig) {
-			// register your extension with host through callback
-			sharedConfig.onBuildChanged((build: TFSBuildContracts.Build) => {
-				this.taskClient = DTClient.getClient();
-				this.projectId = vsoContext.project.id;
-				this.planId = build.orchestrationPlan.planId;
+  public initialize = (): void => {
+    super.initialize();
+    // Get configuration that's shared between extension and the extension host
+    const sharedConfig: TFSBuildExtensionContracts.IBuildResultsViewExtensionConfig = VSS.getConfiguration();
+    const vsoContext = VSS.getWebContext();
+    if (sharedConfig) {
+      // register your extension with host through callback
+      sharedConfig.onBuildChanged((build: TFSBuildContracts.Build) => {
+        this.taskClient = DTClient.getClient();
+        this.projectId = vsoContext.project.id;
+        this.planId = build.orchestrationPlan.planId;
 
-				const reportListElem: HTMLElement = (document.getElementById('reportList') as HTMLElement);
+        const reportListElem: HTMLElement = document.getElementById(
+          'reportList'
+        ) as HTMLElement;
 
-				this.taskClient.getPlanAttachments(
-					this.projectId,
-					BUILD_PHASE,
-					this.planId,
-					HTML_ATTACHMENT_TYPE
-				)
-				.then((taskAttachments) => {
-					$.each(taskAttachments, (index, taskAttachment) => {
-						const attachmentName = taskAttachment.name;
-						const timelineId = taskAttachment.timelineId;
-						const recordId = taskAttachment.recordId;
+        this.taskClient
+          .getPlanAttachments(
+            this.projectId,
+            BUILD_PHASE,
+            this.planId,
+            HTML_ATTACHMENT_TYPE
+          )
+          .then((taskAttachments) => {
+            $.each(taskAttachments, (index, taskAttachment) => {
+              const attachmentName = taskAttachment.name;
+              const timelineId = taskAttachment.timelineId;
+              const recordId = taskAttachment.recordId;
 
-						if (taskAttachment._links && taskAttachment._links.self && taskAttachment._links.self.href) {
-							const reportItem = this.createReportItem(
-								index,
-								attachmentName,
-								timelineId,
-								recordId
-							);
-							this.appendReportItem(reportListElem, reportItem);
+              if (
+                taskAttachment._links &&
+                taskAttachment._links.self &&
+                taskAttachment._links.self.href
+              ) {
+                const reportItem = this.createReportItem(
+                  index,
+                  attachmentName,
+                  timelineId,
+                  recordId
+                );
+                this.appendReportItem(reportListElem, reportItem);
 
-							const jsonName = `${attachmentName.split(".")[0]}.json`;
-							this.taskClient.getAttachmentContent(
-								this.projectId,
-								BUILD_PHASE,
-								this.planId,
-								timelineId,
-								recordId,
-								JSON_ATTACHMENT_TYPE,
-								jsonName
-							)
-							.then((content) => {
-								const json = JSON.parse(new TextDecoder("utf-8").decode((new DataView(content))));
-								this.improveReportDisplayName(attachmentName, json, reportItem);
-							});
+                const jsonName = `${attachmentName.split('.')[0]}.json`;
+                this.taskClient
+                  .getAttachmentContent(
+                    this.projectId,
+                    BUILD_PHASE,
+                    this.planId,
+                    timelineId,
+                    recordId,
+                    JSON_ATTACHMENT_TYPE,
+                    jsonName
+                  )
+                  .then((content) => {
+                    const json = JSON.parse(
+                      new TextDecoder('utf-8').decode(new DataView(content))
+                    );
+                    this.improveReportDisplayName(
+                      attachmentName,
+                      json,
+                      reportItem
+                    );
+                  });
 
-							if (this.reportList.length == 1) this.reportList[0].click();
-							VSS.notifyLoadSucceeded();
-						}
-					});
-				});
-			});
-		}
-	}
+                if (this.reportList.length == 1) this.reportList[0].click();
+                VSS.notifyLoadSucceeded();
+              }
+            });
+          });
+      });
+    }
+  };
 
-	private improveReportDisplayName = (attachmentName:string, json: string, reportItem: HTMLElement):void => {
-		const img: HTMLImageElement = document.createElement("img");
-		const span: HTMLElement = document.createElement("span");
-		let spanText: string = "";
+  private improveReportDisplayName = (
+    attachmentName: string,
+    jsonResults: object | any[],
+    reportItem: HTMLElement
+  ): void => {
+    // TODO: should we fail in this case? Or is this a valid state?
+    if (!jsonResults) {
+      return;
+    }
 
-		if (json) {
-			if (json["docker"] && json["docker"]["baseImage"])
-				spanText = `Snyk Test for ${json["docker"]["baseImage"]} (${this.formatReportName(attachmentName)})`;
+    const img: HTMLImageElement = document.createElement('img');
+    const span: HTMLElement = document.createElement('span');
+    const vulnsFound = detectVulns(jsonResults);
+    const spanText = generateReportTitle(jsonResults, attachmentName);
 
-			if (json["packageManager"])
-				spanText = `Snyk Test for ${json["packageManager"]} (${this.formatReportName(attachmentName)})`;
+    $(reportItem).addClass(vulnsFound ? 'failed' : 'passed');
+    img.src = vulnsFound
+      ? '../img/report-failed.png'
+      : '../img/report-passed.png';
+    $(img).addClass('reportImg');
+    $(span).text(spanText);
+    reportItem.appendChild(img);
+    reportItem.appendChild(span);
+  };
 
-			if (json["uniqueCount"] && json["uniqueCount"] > 0) {
-				$(reportItem).addClass("failed");
-				img.src = "../img/report-failed.png";
-				spanText = `${spanText} | Found ${json["uniqueCount"]} issues`;
-			}
-			else {
-				$(reportItem).addClass("passed");
-				img.src = "../img/report-passed.png";
-				spanText = `${spanText} | No issues found`
-			}
-		}
-		$(img).addClass("reportImg");
-		$(span).text(spanText);
-		reportItem.appendChild(img);
-		reportItem.appendChild(span);
-	}
+  private createReportItem = (
+    index: string | number | symbol,
+    attachmentName: string,
+    timelineId: string,
+    recordId: string
+  ): HTMLElement => {
+    const reportItem = document.createElement('li');
+    $(reportItem).addClass('report');
+    reportItem.onclick = () =>
+      this.showReport(index, attachmentName, timelineId, recordId);
 
-	private createReportItem = (index: string | number | symbol, attachmentName:string, timelineId: string, recordId: string): HTMLElement => {
-		const reportItem = document.createElement('li');
-		$(reportItem).addClass("report");
-		reportItem.onclick = (e) => this.showReport(index, attachmentName, timelineId, recordId);
+    return reportItem;
+  };
 
-		return reportItem;
-	}
+  private appendReportItem = (list: HTMLElement, item: HTMLElement): void => {
+    this.reportList.push(item);
+    list.appendChild(item);
+  };
 
-	private appendReportItem = (list: HTMLElement, item: HTMLElement): void => {
-		this.reportList.push(item);
-		list.appendChild(item);
-	}
+  private showReport = (
+    index: string | number | symbol,
+    attachmentName: string,
+    timelineId: string,
+    recordId: string
+  ): void => {
+    $.each(this.reportList, (index, reportItem) =>
+      $(reportItem).removeClass('currentReport')
+    );
+    $(this.reportList[index]).addClass('currentReport');
+    const content: string = '<h3> Loading report... </h3>';
+    this.fillReportIFrameContent(content);
 
-	private formatReportName = (name: string): string => {
-		let reportName = name.split(".")[0];
-		const tmpName = reportName.split("T");
-		return  `${tmpName[0]} ${tmpName[1].replace(/-/g,":")}`;
-	}
+    this.taskClient
+      .getAttachmentContent(
+        this.projectId,
+        BUILD_PHASE,
+        this.planId,
+        timelineId,
+        recordId,
+        HTML_ATTACHMENT_TYPE,
+        attachmentName
+      )
+      .then((content) => {
+        const data = new TextDecoder('utf-8').decode(new DataView(content));
+        this.fillReportIFrameContent(data);
+      });
+  };
 
-	private showReport = (index: string | number | symbol, attachmentName: string, timelineId: string, recordId: string): void => {
-		$.each(this.reportList, (index, reportItem) => $(reportItem).removeClass("currentReport"));
-		$(this.reportList[index]).addClass("currentReport")
-		const content: string = "<h3> Loading report... </h3>";
-		this.fillReportIFrameContent(content);
-
-		this.taskClient.getAttachmentContent(
-			this.projectId,
-			BUILD_PHASE,
-			this.planId,
-			timelineId,
-			recordId,
-			HTML_ATTACHMENT_TYPE,
-			attachmentName
-		)
-		.then((content) => {
-			const data = new TextDecoder("utf-8").decode((new DataView(content)));
-			this.fillReportIFrameContent(data);
-		});
-	}
-
-	private fillReportIFrameContent = (content: string): void => {
-		(document.getElementById('iframeID') as HTMLDivElement).innerHTML = content;
-	}
+  private fillReportIFrameContent = (content: string): void => {
+    (document.getElementById('iframeID') as HTMLDivElement).innerHTML = content;
+  };
 }
 
-SnykReportTab.enhance(SnykReportTab, $("#snyk-report"), {});
+SnykReportTab.enhance(SnykReportTab, $('#snyk-report'), {});

--- a/ui/enhancer/tsconfig.json
+++ b/ui/enhancer/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5", // revert to es6                      /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+    "target": "es6", // revert to es6                      /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
     "module": "amd",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "outDir": "../../scripts/dist",                        /* Redirect output structure to the directory. */
 
@@ -13,9 +13,9 @@
     "types": [                                /* Type declaration files to be included in compilation. */
       "vss-web-extension-sdk",
       "jquery"
-    ],                           
+    ],
     "esModuleInterop": true,                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
-    
+
     /* Source Map Options */
     "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
     "inlineSources": true                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */


### PR DESCRIPTION
This fixes UI for an output of test with `--all-projects` flag.

Added some basic tests as well

Removed a Jest flag `--detectOpenHandles`, as it was messing with test mocks.

> Attempt to collect and print open handles preventing Jest from exiting cleanly. Use this in cases where you need to use --forceExit in order for Jest to exit to potentially track down the reason. This implies --runInBand, making tests run serially. Implemented using async_hooks. **This option has a significant performance penalty and should only be used for debugging.**
> https://jestjs.io/docs/cli#--detectopenhandles
