### PR TITLE
feat: supports critical as a valid severity threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,36 +8,37 @@ This task/extension for Azure Pipelines allows you to easily run Snyk scans with
 In addition to running a Snyk security scan, you also have the option to monitor your application / container, in which case the dependency tree or container image metadata will be posted to your Snyk account for ongoing monitoring.
 
 ## Requirements
-This extension requires that Node.js and npm be installed on the build agent. These are available by default on all Microsoft-hosted build agents. However, if you are using a self-hosted build agent, you may need to explicitly activate Node.js and npm and ensure they are in your [PATH](https://en.wikipedia.org/wiki/PATH_(variable)). This can be done using the [NodeTool task from Microsoft](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/node-js?view=azure-devops) prior to the `SnykSecurityScan` task in your pipeline.
+
+This extension requires that Node.js and npm be installed on the build agent. These are available by default on all Microsoft-hosted build agents. However, if you are using a self-hosted build agent, you may need to explicitly activate Node.js and npm and ensure they are in your [PATH](<https://en.wikipedia.org/wiki/PATH_(variable)>). This can be done using the [NodeTool task from Microsoft](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/node-js?view=azure-devops) prior to the `SnykSecurityScan` task in your pipeline.
 
 ## How to use the Snyk task for Azure DevOps Pipelines
+
 1. Install the [extension](https://marketplace.visualstudio.com/items?itemName=Snyk.snyk-security-scan) into your Azure DevOps environment.
 2. Configure a service connection endpoint with your Snyk token. This is done at the project level. In Azure DevOps, go to Project settings -> Service connections -> New service connection -> Snyk Authentication. Give your service connection and enter a valid Snyk Token.
 3. Within an Azure DevOps Pipeline, add the Snyk Security Scan task and configure it according to your needs according to details and examples below.
 
-
 ## Task Parameters
 
-| Parameter  | Description | Required | Default | Type |
-| -----------------|-------------------------------------------------------------------|---------------|---------------|---------------|
-| serviceConnectionEndpoint | The Azure DevOps service connection endpoint where your Snyk API token is defined. Define this within your Azure DevOps project settings / S | no | none | String / Azure Service Connection Endpoint of type SnykAuth / Snyk Authentication |
-| testType | Used by the task UI only | no | "application" | string: "app" or "container" |
-| dockerImageName | The name of the container image to test. | yes, if container image test | none | string |
-| dockerfilePath | The path to the Dockerfile corresponding to the `dockerImageName` | yes, if container image test | none | string |
-| targetFile | Applicable to application type tests ony. The path to the manifest file to be used by Snyk. Should only be provided if non-standard. | no | none | string |
-| severityThreshold | The severity-threshold to use when testing. By default, issues of all severity types will be found. | no | "low" | string: "low" or "medium" or "high" |
-| monitorOnBuild | Whether or not to capture the dependencies of the application / container image and monitor them within Snyk. | yes | true | boolean |
-| failOnIssues | This specifies if builds should be failed or continued based on issues found by Snyk. | yes | true | boolean |
-| projectName | A custom name for the Snyk project to be created on snyk.io | no | none | string |
-| organization | Name of the Snyk organisation name, under which this project should be tested and monitored | no | none | string |
-| testDirectory | Alternate working directory. For example, if you want to test a manifest file in a directory other than the root of your repo, you would put in relative path to that directory. | no | none | string |
-| ignoreUnknownCA | Use to ignore unknown or self-signed certificates. This might be useful in for self-hosted build agents with unusual network configurations or for Snyk on-prem installs configured with a self-signed certificate. | no | false | boolean |
-| additionalArguments | Additional Snyk CLI arguments to be passed in. Refer to the Snyk CLI help page for information on additional arguments. | no | none | string |
-
+| Parameter                 | Description                                                                                                                                                                                                         | Required                     | Default       | Type                                                                              |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- | ------------- | --------------------------------------------------------------------------------- |
+| serviceConnectionEndpoint | The Azure DevOps service connection endpoint where your Snyk API token is defined. Define this within your Azure DevOps project settings / S                                                                        | no                           | none          | String / Azure Service Connection Endpoint of type SnykAuth / Snyk Authentication |
+| testType                  | Used by the task UI only                                                                                                                                                                                            | no                           | "application" | string: "app" or "container"                                                      |
+| dockerImageName           | The name of the container image to test.                                                                                                                                                                            | yes, if container image test | none          | string                                                                            |
+| dockerfilePath            | The path to the Dockerfile corresponding to the `dockerImageName`                                                                                                                                                   | yes, if container image test | none          | string                                                                            |
+| targetFile                | Applicable to application type tests ony. The path to the manifest file to be used by Snyk. Should only be provided if non-standard.                                                                                | no                           | none          | string                                                                            |
+| severityThreshold         | The severity-threshold to use when testing. By default, issues of all severity types will be found.                                                                                                                 | no                           | "low"         | string: "low" or "medium" or "high" or "critical"                                 |
+| monitorOnBuild            | Whether or not to capture the dependencies of the application / container image and monitor them within Snyk.                                                                                                       | yes                          | true          | boolean                                                                           |
+| failOnIssues              | This specifies if builds should be failed or continued based on issues found by Snyk.                                                                                                                               | yes                          | true          | boolean                                                                           |
+| projectName               | A custom name for the Snyk project to be created on snyk.io                                                                                                                                                         | no                           | none          | string                                                                            |
+| organization              | Name of the Snyk organisation name, under which this project should be tested and monitored                                                                                                                         | no                           | none          | string                                                                            |
+| testDirectory             | Alternate working directory. For example, if you want to test a manifest file in a directory other than the root of your repo, you would put in relative path to that directory.                                    | no                           | none          | string                                                                            |
+| ignoreUnknownCA           | Use to ignore unknown or self-signed certificates. This might be useful in for self-hosted build agents with unusual network configurations or for Snyk on-prem installs configured with a self-signed certificate. | no                           | false         | boolean                                                                           |
+| additionalArguments       | Additional Snyk CLI arguments to be passed in. Refer to the Snyk CLI help page for information on additional arguments.                                                                                             | no                           | none          | string                                                                            |
 
 ## Usage Examples
 
 ### Simple Application Testing Example
+
 ```
 - task: SnykSecurityScan@0
   inputs:
@@ -47,8 +48,8 @@ This extension requires that Node.js and npm be installed on the build agent. Th
     failOnIssues: true
 ```
 
-
 ### Simple Container Image Testing Example
+
 ```
 - task: SnykSecurityScan@0
   inputs:

--- a/snykTask/src/__tests__/task-lib-severity-threshold.test.ts
+++ b/snykTask/src/__tests__/task-lib-severity-threshold.test.ts
@@ -1,0 +1,20 @@
+import { isNotValidThreshold, Severity } from "../task-lib";
+
+describe("isNotValidThreshold", () => {
+  const validSeverityThresholds = [
+    Severity.CRITICAL,
+    Severity.HIGH,
+    Severity.MEDIUM,
+    Severity.LOW
+  ];
+  test("returns true if invalid severity threshold", () => {
+    const isInvalid = isNotValidThreshold("hey");
+    expect(isInvalid).toBe(true);
+  });
+
+  describe.each(validSeverityThresholds)("isNotValidThreshold(%s)", level => {
+    test(`returns false for ${level}`, () => {
+      expect(isNotValidThreshold(level)).toBe(false);
+    });
+  });
+});

--- a/snykTask/src/index.ts
+++ b/snykTask/src/index.ts
@@ -13,7 +13,9 @@ import {
   attachReport,
   removeRegexFromFile,
   JSON_ATTACHMENT_TYPE,
-  HTML_ATTACHMENT_TYPE
+  HTML_ATTACHMENT_TYPE,
+  isNotValidThreshold,
+  Severity
 } from "./task-lib";
 import * as fs from "fs";
 import * as path from "path";
@@ -87,8 +89,7 @@ function parseInputArgs(): TaskArgs {
   if (taskArgs.severityThreshold) {
     taskArgs.severityThreshold = taskArgs.severityThreshold.toLowerCase();
     if (isNotValidThreshold(taskArgs.severityThreshold)) {
-      const errorMsg =
-        "If set, severity threshold must be 'high' or 'medium' or 'low' (case insensitive). If not set, the default is 'low'.";
+      const errorMsg = `If set, severity threshold must be '${Severity.CRITICAL}' or '${Severity.HIGH}' or '${Severity.MEDIUM}' or '${Severity.LOW}' (case insensitive). If not set, the default is 'low'.`;
       throw new Error(errorMsg);
     }
   }
@@ -100,16 +101,6 @@ function parseInputArgs(): TaskArgs {
 
   return taskArgs;
 }
-
-const isNotValidThreshold = (threshold: string) => {
-  const severityThresholdLowerCase = threshold.toLowerCase();
-
-  return (
-    severityThresholdLowerCase !== "high" &&
-    severityThresholdLowerCase !== "medium" &&
-    severityThresholdLowerCase !== "low"
-  );
-};
 
 const logAllTaskArgs = (taskArgs: TaskArgs) => {
   console.log(`taskArgs.targetFile: ${taskArgs.targetFile}`);

--- a/snykTask/src/task-lib.ts
+++ b/snykTask/src/task-lib.ts
@@ -110,3 +110,21 @@ export function removeRegexFromFile(
     }
   }
 }
+
+export enum Severity {
+  CRITICAL = "critical",
+  HIGH = "high",
+  MEDIUM = "medium",
+  LOW = "low"
+}
+
+export function isNotValidThreshold(threshold: string) {
+  const severityThresholdLowerCase = threshold.toLowerCase();
+
+  return (
+    severityThresholdLowerCase !== Severity.CRITICAL &&
+    severityThresholdLowerCase !== Severity.HIGH &&
+    severityThresholdLowerCase !== Severity.MEDIUM &&
+    severityThresholdLowerCase !== Severity.LOW
+  );
+}

--- a/snykTask/task.json
+++ b/snykTask/task.json
@@ -84,7 +84,8 @@
       "options": {
         "low": "Low (default)",
         "medium": "Medium",
-        "high": "High"
+        "high": "High",
+        "critical": "Critical"
       },
       "helpMarkDown": "The testing severity threshold. Leave blank for no threshold."
     },


### PR DESCRIPTION
As part of work being done APOLLO-97 this ensures critical becomes a valid severity threshold to use in reporting. The CLI test currently returns critical severities from 1.456.0 onwards with sarif support from version 1.514.0.