### PR TITLE
chore: separate prod build and publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ jobs:
           command: |
             node ./ops/deploy/dist/run-test-pipelines.js
 
-  deploy:
+  build_prod:
     docker:
       - image: circleci/node:lts
         environment:
@@ -111,6 +111,30 @@ jobs:
             npm install
             npx semantic-release
 
+      - store_artifacts:
+          path: ./Snyk-snyk-security-scan.vsix
+      
+      - persist_to_workspace:
+          root: .
+          paths:
+            - ./Snyk-snyk-security-scan.vsix
+
+  publish:
+    docker:
+      - image: circleci/node:lts
+        environment:
+          AZ_EXTENSION_ID: "snyk-security-scan"
+          AZ_EXTENSION_NAME: "Snyk Security Scan"
+          AZ_PUBLISHER: "Snyk"
+    working_directory: ~/repo
+    steps:
+      - attach_workspace:
+          at: ~/repo
+      - run:
+          name: Publish to Marketplace
+          command: |
+            tfx extension publish --token $AZURE_DEVOPS_EXT_PAT --vsix Snyk-snyk-security-scan.vsix
+
 workflows:
   version: 2
   build_and_test:
@@ -122,10 +146,18 @@ workflows:
           filters:
             branches:
               ignore: master
-      - deploy:
+      - build_prod:
           context: nodejs-lib-release
           requires:
             - test
           filters:
             branches:
               only: master
+      - hold:
+          type: approval
+          requires:
+           - build_prod
+      - publish:
+          context: nodejs-lib-release
+          requires:
+            - hold

--- a/scripts/ci-deploy-prod.sh
+++ b/scripts/ci-deploy-prod.sh
@@ -15,12 +15,14 @@ OVERRIDE_JSON="{ \"id\": \"${AZ_EXTENSION_ID}\", \"name\": \"${AZ_EXTENSION_NAME
 
 # Publish extension
 echo "Publishing extension..."
-tfx extension publish --manifest-globs vss-extension.json \
+tfx extension create \
+--manifest-globs vss-extension.json \
 --version $AZ_EXT_NEW_VERSION \
 --extension-id $AZ_EXTENSION_ID \
 --publisher $AZ_PUBLISHER \
 --override $OVERRIDE_JSON \
---token $AZURE_DEVOPS_EXT_PAT
+--token $AZURE_DEVOPS_EXT_PAT \
+--output-path Snyk-snyk-security-scan.vsix
 
 publish_exit_code=$?
 if [[ publish_exit_code -eq 0 ]]; then


### PR DESCRIPTION
- Separate the build and publish parts of the production release for more control and visibility
- Add a `hold` job for manual approval before releasing
