### PR TITLE
Option to install snyk with binary release

### DIFF
--- a/snykTask/src/__tests__/install/index.test.ts
+++ b/snykTask/src/__tests__/install/index.test.ts
@@ -1,0 +1,49 @@
+import { getSnykDownloadInfo, downloadExecutable } from "../../install";
+import { Platform } from "azure-pipelines-task-lib/task";
+
+describe("getSnykDownloadInfo", () => {
+  it("retrieves the correct download info for Linux", () => {
+    const dlInfo = getSnykDownloadInfo(Platform.Linux);
+    expect(dlInfo).toEqual({
+      snyk: {
+        filename: "snyk-linux",
+        downloadUrl: "https://static.snyk.io/cli/latest/snyk-linux"
+      },
+      snykToHtml: {
+        filename: "snyk-to-html-linux",
+        downloadUrl:
+          "https://static.snyk.io/snyk-to-html/latest/snyk-to-html-linux"
+      }
+    });
+  });
+
+  it("retrieves the correct download info for Windows", () => {
+    const dlInfo = getSnykDownloadInfo(Platform.Windows);
+    expect(dlInfo).toEqual({
+      snyk: {
+        filename: "snyk-win.exe",
+        downloadUrl: "https://static.snyk.io/cli/latest/snyk-win.exe"
+      },
+      snykToHtml: {
+        filename: "snyk-to-html-win.exe",
+        downloadUrl:
+          "https://static.snyk.io/snyk-to-html/latest/snyk-to-html-win.exe"
+      }
+    });
+  });
+
+  it("retrieves the correct download info for MacOS", () => {
+    const dlInfo = getSnykDownloadInfo(Platform.MacOS);
+    expect(dlInfo).toEqual({
+      snyk: {
+        filename: "snyk-macos",
+        downloadUrl: "https://static.snyk.io/cli/latest/snyk-macos"
+      },
+      snykToHtml: {
+        filename: "snyk-to-html-macos",
+        downloadUrl:
+          "https://static.snyk.io/snyk-to-html/latest/snyk-to-html-macos"
+      }
+    });
+  });
+});

--- a/snykTask/src/__tests__/task-lib.test.ts
+++ b/snykTask/src/__tests__/task-lib.test.ts
@@ -42,7 +42,8 @@ test("getOptionsToExecuteSnykCLICommand builds IExecOptions like we need it", ()
   const options: tr.IExecOptions = getOptionsToExecuteSnykCLICommand(
     taskArgs,
     taskNameForAnalytics,
-    version
+    version,
+    "fake-token"
   );
 
   expect(options.cwd).toBe("/some/path");
@@ -50,6 +51,7 @@ test("getOptionsToExecuteSnykCLICommand builds IExecOptions like we need it", ()
   expect(options.ignoreReturnCode).toBe(true);
   expect(options.env?.SNYK_INTEGRATION_NAME).toBe("AZURE_PIPELINES");
   expect(options.env?.SNYK_INTEGRATION_VERSION).toBe(version);
+  expect(options.env?.SNYK_TOKEN).toBe("fake-token");
 });
 
 test("getOptionsForSnykToHtml builds IExecOptions for running snyk-to-html", () => {

--- a/snykTask/src/install/index.ts
+++ b/snykTask/src/install/index.ts
@@ -1,0 +1,54 @@
+import { Platform } from "azure-pipelines-task-lib/task";
+import * as fs from "fs";
+import * as path from "path";
+import * as https from "https";
+
+export type Executable = {
+  filename: string;
+  downloadUrl: string;
+};
+
+export type SnykDownloads = {
+  snyk: Executable;
+  snykToHtml: Executable;
+};
+
+export function getSnykDownloadInfo(platform: Platform): SnykDownloads {
+  const baseUrl = "https://static.snyk.io";
+
+  const filenameSuffixes: Record<Platform, string> = {
+    [Platform.Linux]: "linux",
+    [Platform.Windows]: "win.exe",
+    [Platform.MacOS]: "macos"
+  };
+
+  return {
+    snyk: {
+      filename: `snyk-${filenameSuffixes[platform]}`,
+      downloadUrl: `${baseUrl}/cli/latest/snyk-${filenameSuffixes[platform]}`
+    },
+    snykToHtml: {
+      filename: `snyk-to-html-${filenameSuffixes[platform]}`,
+      downloadUrl: `${baseUrl}/snyk-to-html/latest/snyk-to-html-${filenameSuffixes[platform]}`
+    }
+  };
+}
+
+export async function downloadExecutable(
+  targetDirectory: string,
+  executable: Executable
+) {
+  const fileWriter = fs.createWriteStream(
+    path.join(targetDirectory, executable.filename),
+    {
+      mode: 0o766
+    }
+  );
+  return new Promise<void>((resolve, reject) => {
+    https.get(executable.downloadUrl, response => {
+      response.on("end", () => resolve());
+      response.on("error", err => reject(err));
+      response.pipe(fileWriter);
+    });
+  });
+}

--- a/snykTask/src/task-lib.ts
+++ b/snykTask/src/task-lib.ts
@@ -20,19 +20,20 @@ export const getOptionsToExecuteCmd = (taskArgs: TaskArgs): tr.IExecOptions => {
 export const getOptionsToExecuteSnykCLICommand = (
   taskArgs: TaskArgs,
   taskNameForAnalytics: string,
-  taskVersion: string
+  taskVersion: string,
+  snykToken: string
 ): tr.IExecOptions => {
-  const envVars = process.env;
-  envVars["SNYK_INTEGRATION_NAME"] = taskNameForAnalytics;
-  envVars["SNYK_INTEGRATION_VERSION"] = taskVersion;
-
   const options = {
     cwd: taskArgs.testDirectory,
     failOnStdErr: false,
     ignoreReturnCode: true,
-    env: envVars
+    env: {
+      ...process.env,
+      SNYK_INTEGRATION_NAME: taskNameForAnalytics,
+      SNYK_INTEGRATION_VERSION: taskVersion,
+      SNYK_TOKEN: snykToken
+    } as tr.IExecOptions["env"]
   } as tr.IExecOptions;
-
   return options;
 };
 


### PR DESCRIPTION
- Install both `snyk` and `snyk-to-html` by downloading the binary distributions and saving them to the Agent.TempDirectory.
- Instead of calling `snyk auth` we just pass the Snyk token via env var