### PR TITLE
Cleanup leftover code

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "eslint-config-prettier": "^6.1.0",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jest": "^22.15.2",
+    "fs-extra": "^9.1.0",
     "jest": "^26.4.2",
     "mock-fs": "^4.10.4",
     "prettier": "^2.3.1",

--- a/snykTask/src/__tests__/install/index.test.ts
+++ b/snykTask/src/__tests__/install/index.test.ts
@@ -1,4 +1,4 @@
-import { getSnykDownloadInfo, downloadExecutable } from '../../install';
+import { getSnykDownloadInfo } from '../../install';
 import { Platform } from 'azure-pipelines-task-lib/task';
 
 describe('getSnykDownloadInfo', () => {

--- a/snykTask/src/__tests__/task-lib.test.ts
+++ b/snykTask/src/__tests__/task-lib.test.ts
@@ -8,9 +8,6 @@ import {
   getOptionsToExecuteSnykCLICommand,
   getOptionsToExecuteCmd,
   getOptionsForSnykToHtml,
-  isSudoMode,
-  getToolPath,
-  sudoExists,
   formatDate,
   attachReport,
   removeRegexFromFile,
@@ -67,46 +64,6 @@ test('getOptionsForSnykToHtml builds IExecOptions for running snyk-to-html', () 
   expect(options.failOnStdErr).toBe(false);
   expect(options.ignoreReturnCode).toBe(true);
   expect(options.outStream).toBeInstanceOf(stream.Writable);
-});
-
-test('isSudoMode returns true only for Linux platforms', () => {
-  const pLinux = tl.Platform.Linux;
-  const pMacos = tl.Platform.MacOS;
-  const pWindows = tl.Platform.Windows;
-
-  expect(isSudoMode(pLinux)).toBe(true);
-  expect(isSudoMode(pMacos)).toBe(false);
-  expect(isSudoMode(pWindows)).toBe(false);
-});
-
-test('sudoExists works', () => {
-  const whichSpy = jest.spyOn(tl, 'which').mockReturnValue('/usr/bin/sudo');
-  expect(sudoExists()).toBe(true);
-
-  whichSpy.mockReturnValue('');
-  expect(sudoExists()).toBe(false);
-});
-
-test('getToolPath returns sudo if require and not if not required', () => {
-  // mock the which function from the azure-pipelines-task-lib/task
-  const mockTlWhichFn = jest
-    .fn()
-    .mockImplementation((tool: string, check?: boolean) => {
-      return `/usr/bin/${tool}`;
-    });
-
-  expect(mockTlWhichFn('anything')).toBe('/usr/bin/anything');
-  expect(mockTlWhichFn('sudo')).toBe('/usr/bin/sudo');
-
-  expect(getToolPath('some-command', mockTlWhichFn)).toBe(
-    '/usr/bin/some-command',
-  );
-  expect(getToolPath('some-command', mockTlWhichFn, false)).toBe(
-    '/usr/bin/some-command',
-  );
-  expect(getToolPath('some-command', mockTlWhichFn, true)).toBe(
-    '/usr/bin/sudo',
-  );
 });
 
 test('formatDate gives format we want for the report filename', () => {

--- a/snykTask/src/index.ts
+++ b/snykTask/src/index.ts
@@ -6,9 +6,6 @@ import {
   getOptionsToExecuteCmd,
   getOptionsToExecuteSnykCLICommand,
   getOptionsForSnykToHtml,
-  isSudoMode,
-  getToolPath,
-  sudoExists,
   formatDate,
   attachReport,
   removeRegexFromFile,
@@ -146,8 +143,6 @@ async function runSnykTest(
     snykToken,
   );
 
-  const command = `[command]${getToolPath('snyk', tl.which)} snyk test...`;
-  console.log(command);
   const snykTestExitCode = await snykTestToolRunner.exec(options);
   if (isDebugMode()) console.log(`snykTestExitCode: ${snykTestExitCode}\n`);
 
@@ -184,12 +179,6 @@ const runSnykToHTML = async (
 
   let code = 0;
   let errorMsg = '';
-
-  const command = `[command]${getToolPath(
-    'snyk-to-html',
-    tl.which,
-  )} -i ${jsonReportFullPath}`;
-  console.log(command);
 
   const snykToHTMLToolRunner = tl
     .tool(snykToHtmlPath)
@@ -334,18 +323,6 @@ async function run() {
 
     const platform: tl.Platform = tl.getPlatform();
     if (isDebugMode()) console.log(`platform: ${platform}`);
-
-    const sudoMode = isSudoMode(platform);
-    if (isDebugMode()) console.log(`sudoMode: ${sudoMode}`);
-
-    let useSudo = false;
-    if (sudoMode) {
-      const sudoExistOnBuildMachine = sudoExists();
-      if (isDebugMode())
-        console.log(`sudoExistOnBuildMachine: ${sudoExistOnBuildMachine}`);
-      useSudo = sudoExistOnBuildMachine;
-    }
-    if (isDebugMode()) console.log(`useSudo: ${useSudo}`);
 
     const agentTempDirectory = tl.getVariable('Agent.TempDirectory');
     if (!agentTempDirectory) {

--- a/snykTask/src/index.ts
+++ b/snykTask/src/index.ts
@@ -246,12 +246,15 @@ async function runSnykMonitor(
   return snykOutput;
 }
 
-const handleSnykTestError = (args, snykTestResult, workDir, fileName) => {
+const handleSnykTestError = (
+  args,
+  snykTestResult,
+  jsonReportFullPath: string,
+) => {
   if (snykTestResult.code >= CLI_EXIT_CODE_INVALID_USE) {
     let errorMsg = snykTestResult.message;
-    const filePath = `${workDir}/${fileName}`;
-    if (fs.existsSync(filePath)) {
-      const snykErrorResponse = fs.readFileSync(filePath, 'utf8');
+    if (fs.existsSync(jsonReportFullPath)) {
+      const snykErrorResponse = fs.readFileSync(jsonReportFullPath, 'utf8');
       if (isDebugMode()) console.log(snykErrorResponse);
 
       const snykErrorJSONResponse = JSON.parse(snykErrorResponse);
@@ -280,35 +283,23 @@ async function run() {
     const currentDir: string = tl.cwd(); // Azure mock framework will return empty string / undefined
     if (isDebugMode()) console.log(`currentWorkingDirectory: ${currentDir}\n`);
 
-    const reportOutputDir = tl.getVariable('Agent.TempDirectory') || ''; // Azure mock framework will return empty string / undefined
-    if (isDebugMode()) console.log(`reportOutputDir: ${reportOutputDir}\n`);
-
-    // Hack for Azure framework mock test
-    // The test that use the Azure mock framework rely on knowing the output path and filename of the reports
-    // in order to verify proper functioning of the task.
-    // But, tl.getVariable() is not mocked and always an empty string (or undefined?) when those tests run. Also, the date/time
-    // becomes part of the report filenames.
-    // So a hack here to make those task-tests work is to set the 'now' timestamp string to "" for the tests and to use the default
-    // directory "" - this way the paths will match those in snykTask/src/__tests__/test-task.ts and snykTask/src/__tests__/_test-mock-config-*.ts.
-    // But when the task runs for real in Azure Pipelines, the paths will have a full path and a timestamp in the filenames.
-
-    let jsonReportName = 'report.json';
-    let htmlReportName = 'report.html';
-    let jsonReportFullPath = jsonReportName;
-    let htmlReportFullPath = htmlReportName;
-
-    if (reportOutputDir) {
-      const dNowStr = formatDate(new Date());
-      jsonReportName = `report-${dNowStr}.json`;
-      htmlReportName = `report-${dNowStr}.html`;
-      jsonReportFullPath = path.join(reportOutputDir, jsonReportName);
-      htmlReportFullPath = path.join(reportOutputDir, htmlReportName);
+    const agentTempDirectory = tl.getVariable('Agent.TempDirectory');
+    if (!agentTempDirectory) {
+      throw new Error('Agent.TempDirectory is not set'); // should always be set by Azure Pipelines environment
     }
 
+    const dNowStr = formatDate(new Date());
+    const jsonReportFullPath = path.join(
+      agentTempDirectory,
+      `report-${dNowStr}.json`,
+    );
+    const htmlReportFullPath = path.join(
+      agentTempDirectory,
+      `report-${dNowStr}.html`,
+    );
+
     if (isDebugMode()) {
-      console.log(`reportOutputDir: ${reportOutputDir}`);
-      console.log(`jsonReportName: ${jsonReportName}`);
-      console.log(`htmlReportName: ${htmlReportName}`);
+      console.log(`agentTempDirectory: ${agentTempDirectory}`);
       console.log(`jsonReportFullPath: ${jsonReportFullPath}`);
       console.log(`htmlReportFullPath: ${htmlReportFullPath}`);
     }
@@ -324,10 +315,6 @@ async function run() {
     const platform: tl.Platform = tl.getPlatform();
     if (isDebugMode()) console.log(`platform: ${platform}`);
 
-    const agentTempDirectory = tl.getVariable('Agent.TempDirectory');
-    if (!agentTempDirectory) {
-      throw new Error('Agent.TempDirectory is not set'); // should always be set by Azure Pipelines environment
-    }
     const snykToolDownloads = getSnykDownloadInfo(platform);
     await downloadExecutable(agentTempDirectory, snykToolDownloads.snyk);
     await downloadExecutable(agentTempDirectory, snykToolDownloads.snykToHtml);
@@ -346,7 +333,7 @@ async function run() {
       console.log('showing contents of agent temp directory...');
       await showDirectoryListing(
         getOptionsToExecuteCmd(taskArgs),
-        reportOutputDir,
+        agentTempDirectory,
       );
     }
 
@@ -392,18 +379,13 @@ async function run() {
       console.log('showing contents of agent temp directory...');
       await showDirectoryListing(
         getOptionsToExecuteCmd(taskArgs),
-        reportOutputDir,
+        agentTempDirectory,
       );
     }
 
     attachReport(jsonReportFullPath, JSON_ATTACHMENT_TYPE);
     attachReport(htmlReportFullPath, HTML_ATTACHMENT_TYPE);
-    handleSnykTestError(
-      taskArgs,
-      snykTestResult,
-      reportOutputDir,
-      jsonReportName,
-    );
+    handleSnykTestError(taskArgs, snykTestResult, jsonReportFullPath);
 
     if (taskArgs.monitorOnBuild) {
       const snykMonitorResult = await runSnykMonitor(

--- a/snykTask/src/index.ts
+++ b/snykTask/src/index.ts
@@ -247,8 +247,8 @@ async function runSnykMonitor(
 }
 
 const handleSnykTestError = (
-  args,
-  snykTestResult,
+  args: TaskArgs,
+  snykTestResult: SnykOutput,
   jsonReportFullPath: string,
 ) => {
   if (snykTestResult.code >= CLI_EXIT_CODE_INVALID_USE) {
@@ -268,12 +268,12 @@ const handleSnykTestError = (
     throw new SnykError(snykTestResult.message);
 };
 
-const handleSnykToHTMLError = (snykToHTMLResult) => {
+const handleSnykToHTMLError = (snykToHTMLResult: SnykOutput) => {
   if (snykToHTMLResult.code !== CLI_EXIT_CODE_SUCCESS)
     throw new SnykError(snykToHTMLResult.message);
 };
 
-const handleSnykMonitorError = (snykMonitorResult) => {
+const handleSnykMonitorError = (snykMonitorResult: SnykOutput) => {
   if (snykMonitorResult.code !== CLI_EXIT_CODE_SUCCESS)
     throw new SnykError(snykMonitorResult.message);
 };

--- a/snykTask/src/task-lib.ts
+++ b/snykTask/src/task-lib.ts
@@ -1,7 +1,6 @@
 import { TaskArgs } from './task-args';
 import * as tr from 'azure-pipelines-task-lib/toolrunner';
 import * as tl from 'azure-pipelines-task-lib/task';
-import { Platform } from 'azure-pipelines-task-lib/task';
 import stream = require('stream');
 import * as fs from 'fs';
 import * as path from 'path';
@@ -52,27 +51,6 @@ export const getOptionsForSnykToHtml = (
     outStream: writableString,
   } as tr.IExecOptions;
 };
-
-export const isSudoMode = (p: Platform): boolean => {
-  if (typeof p !== 'number') return true; // this may not be a good assumption, but now that we're actually checking if sudo exists, it should be ok
-  return p === Platform.Linux;
-};
-
-export function sudoExists(): boolean {
-  const res = tl.which('sudo'); // will return an empty string if sudo does not exist or a path like `/usr/bin/sudo`
-  // coerce to boolean
-  if (res) {
-    return true;
-  } else {
-    return false;
-  }
-}
-
-export const getToolPath = (
-  tool: string,
-  whichFn: (tool: string, check?: boolean) => string,
-  requiresSudo: boolean = false,
-): string => (requiresSudo ? whichFn('sudo') : whichFn(tool));
 
 export function formatDate(d: Date): string {
   return d.toISOString().split('.')[0].replace(/:/g, '-');


### PR DESCRIPTION
- remove no-longer used sudo related functions, logging and related tests
- cleanup path logic relating reports which is not longer needed since we don't use the `azure-pipelines-task-lib` test  framework (removed in https://github.com/snyk/snyk-azure-pipelines-task/pull/80).

