### PR TITLE
fix: check project-name and org args for test command

### DIFF
--- a/snykTask/src/index.ts
+++ b/snykTask/src/index.ts
@@ -133,6 +133,8 @@ async function runSnykTest(
     .argIf(taskArgs.dockerImageName, `${taskArgs.dockerImageName}`)
     .argIf(fileArg, `--file=${fileArg}`)
     .argIf(taskArgs.ignoreUnknownCA, `--insecure`)
+    .argIf(taskArgs.organization, `--org=${taskArgs.organization}`)
+    .argIf(taskArgs.projectName, `--project-name=${taskArgs.projectName}`)
     .arg(`--json-file-output=${jsonReportOutputPath}`)
     .line(taskArgs.additionalArguments);
 


### PR DESCRIPTION
Following this bug: https://snyk.zendesk.com/agent/tickets/9666

Check the `project-name` and `org` arguments when running the test command.