### PR TITLE
fix(report): update CSS to prevent overflow bug on the report

### DIFF
--- a/ui/snyk-report-tab.html
+++ b/ui/snyk-report-tab.html
@@ -2,6 +2,10 @@
 <html lang="en">
   <head>
     <style>
+      html,
+      body {
+        height: 100%;
+      }
       .container {
         width: 100%;
         height: 100%;
@@ -9,16 +13,6 @@
       }
       .iframeContainer {
         overflow: scroll;
-        padding-top: 56.25%;
-        position: relative;
-      }
-      .iframe {
-        border: 0;
-        height: 100%;
-        left: 0;
-        position: absolute;
-        top: 0;
-        width: 100%;
       }
       .list {
         line-height: 2.5;


### PR DESCRIPTION
Original CSS with "position: absolute" prevented the UI to scroll to the bottom of report in some cases. This uses Flexbox to position the div within the iframe.

<img width="810" alt="Screen Shot 2021-06-15 at 17 25 40" src="https://user-images.githubusercontent.com/1788727/122080978-ff16be80-cdfe-11eb-9bc4-4f31952e63f7.png">
