### PR TITLE
Use Node 10 executor in Azure Pipelines

### DIFF
--- a/ops/deploy/tsconfig.json
+++ b/ops/deploy/tsconfig.json
@@ -19,6 +19,7 @@
 
     /* Source Map Options */
     "inlineSourceMap": true /* Emit a single file with source maps instead of having a separate file. */,
-    "inlineSources": true /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+    "inlineSources": true /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */,
+    "useUnknownInCatchVariables": false
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   "dependencies": {
     "azure-pipelines-task-lib": "2.9.3",
     "jquery": "^3.4.1",
-    "request": "^2.88.0",
     "vss-web-extension-sdk": "^5.141.0"
   },
   "devDependencies": {
@@ -70,7 +69,6 @@
     "mock-fs": "^4.10.4",
     "prettier": "^2.3.1",
     "semantic-release": "^17.0.4",
-    "sync-request": "^6.1.0",
     "tfx-cli": "^0.7.11",
     "ts-jest": "^26.3.0",
     "typescript": "^4.5.2"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@semantic-release/changelog": "^5.0.1",
     "@semantic-release/exec": "^5.0.0",
     "@types/jest": "^24.0.18",
-    "@types/node": "^12.7.1",
+    "@types/node": "^16.11.10",
     "@types/q": "^1.5.2",
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
@@ -73,6 +73,6 @@
     "sync-request": "^6.1.0",
     "tfx-cli": "^0.7.11",
     "ts-jest": "^26.3.0",
-    "typescript": "^3.5.3"
+    "typescript": "^4.5.2"
   }
 }

--- a/snykTask/task.json
+++ b/snykTask/task.json
@@ -148,7 +148,7 @@
     }
   ],
   "execution": {
-    "Node": {
+    "Node10": {
       "target": "./dist/index.js"
     }
   }

--- a/snykTask/tsconfig.json
+++ b/snykTask/tsconfig.json
@@ -14,6 +14,7 @@
 
     /* Source Map Options */
     "inlineSourceMap": true /* Emit a single file with source maps instead of having a separate file. */,
-    "inlineSources": true /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+    "inlineSources": true /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */,
+    "useUnknownInCatchVariables": false
   }
 }


### PR DESCRIPTION
Azure Pipelines is migrating from Node 6 to Node 10 and we're getting this warning:

```
##[warning]This task uses Node 6 execution handler, which will be deprecated soon. If you are the developer of the task - please consider the migration guideline to Node 10 handler - https://aka.ms/migrateTaskNode10. If you are the user - feel free to reach out to the owners of this task to proceed on migration.
```

This PR updates the task in accordance with https://aka.ms/migrateTaskNode10.
