### PR TITLE
feat: supporting failOnThreshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This extension requires that Node.js and npm be installed on the build agent. Th
 | dockerfilePath            | The path to the Dockerfile corresponding to the `dockerImageName`                                                                                                                                                   | yes, if container image test | none          | string                                                                            |
 | targetFile                | Applicable to application type tests ony. The path to the manifest file to be used by Snyk. Should only be provided if non-standard.                                                                                | no                           | none          | string                                                                            |
 | severityThreshold         | The severity-threshold to use when testing. By default, issues of all severity types will be found.                                                                                                                 | no                           | "low"         | string: "low" or "medium" or "high" or "critical"                                 |
+| failOnThreshold           | The severity-threshold to use when determining if the build should fail. Combine with `failOnIssues` to get fine grained control over reporting and build failure behaviour. For example, with `failOnIssues` set to true and `failOnThreshold` to `critical`, all issues would be reported on but only critical issues would cause a build failure                                                                                                            | no                           | "low"         | string: "low" or "medium" or "high" or "critical"                                 |
 | monitorWhen               | When to run `snyk monitor`. Valid options are `always` (default), `noIssuesFound`, and `never`. If set, this option overrides the value of `monitorOnBuild`.                                                        | no                           | "always"      | boolean                                                                           |
 | failOnIssues              | This specifies if builds should be failed or continued based on issues found by Snyk.                                                                                                                               | yes                          | true          | boolean                                                                           |
 | projectName               | A custom name for the Snyk project to be created on snyk.io                                                                                                                                                         | no                           | none          | string                                                                            |
@@ -63,6 +64,18 @@ Here's a full example:
     serviceConnectionEndpoint: 'mySnykToken'
     testType: 'app'
     failOnIssues: false
+    monitorWhen: 'always'
+```
+
+An example that uses the default value for `severityThreshold` (low) but configures `failOnThreshold` to critical. This configuration would _only fail_ the build when critical issues are found, but all issues would be reported back to your snyk project for analysis
+
+```
+- task: SnykSecurityScan@1
+  inputs:
+    serviceConnectionEndpoint: 'mySnykToken'
+    testType: 'app'
+    failOnIssues: true
+    failOnThreshold: 'critical'
     monitorWhen: 'always'
 ```
 

--- a/snykTask/src/__tests__/task-lib.test.ts
+++ b/snykTask/src/__tests__/task-lib.test.ts
@@ -14,6 +14,7 @@ import {
   formatDate,
   attachReport,
   removeRegexFromFile,
+  doVulnerabilitiesExistForFailureThreshold
 } from '../task-lib';
 import { TaskArgs } from '../task-args';
 
@@ -43,6 +44,21 @@ test('getOptionsToExecuteSnyk builds IExecOptions like we need it', () => {
   expect(options.cwd).toBe('/some/path');
   expect(options.failOnStdErr).toBe(false);
   expect(options.ignoreReturnCode).toBe(true);
+});
+
+
+test('finds vulnerabilities greater than medium threshold', async  () => {
+  const fixturePath = 'snykTask/test/fixtures/high-vulnerabilities.json';
+  const itemsFound = await doVulnerabilitiesExistForFailureThreshold(fixturePath, "medium");
+
+  expect(itemsFound).toBe(true);
+});
+
+test('ignores vulnerabilities lower than high threshold', async  () => {
+  const fixturePath = 'snykTask/test/fixtures/low-vulnerabilities.json';
+  const itemsFound = await doVulnerabilitiesExistForFailureThreshold(fixturePath, "high");
+
+  expect(itemsFound).toBe(false);
 });
 
 test('getOptionsToExecuteSnykCLICommand builds IExecOptions like we need it', () => {

--- a/snykTask/src/__tests__/test-task-args.ts
+++ b/snykTask/src/__tests__/test-task-args.ts
@@ -4,6 +4,7 @@
    which I don't want to do. */
 
 import { TaskArgs } from '../task-args';
+import { Severity } from '../task-lib';
 
 function defaultTaskArgs(): TaskArgs {
   return new TaskArgs({
@@ -101,6 +102,38 @@ describe('TaskArgs.setMonitorWhen', () => {
     args.setMonitorWhen('always');
     expect(args.monitorWhen).toBe('always');
   });
+});
+
+describe('TaskArgs.severitySettings', () => {
+  const args = defaultTaskArgs();
+
+  it('passes validation when correct combination of severity and fail on thresholds', () => {
+    args.severityThreshold = Severity.LOW;
+    args.failOnThreshold = Severity.HIGH;
+    args.validate();
+  });
+
+  it('passes validation when only severity level specified', () => {
+    args.severityThreshold = Severity.HIGH;
+    args.validate();
+  });
+
+  it('passes validation when only fail on threshold specified', () => {
+    args.failOnThreshold = Severity.HIGH;
+    args.validate();
+  });
+
+  it('throws error when incorrect combination of severity and fail on thresholds', () => {
+    expect(
+      () => { 
+        args.severityThreshold = Severity.HIGH;
+        args.failOnThreshold = Severity.MEDIUM;
+        args.validate();
+      }
+    ).toThrow(
+      new Error('When both set, fail on threshold must be higher than severity threshold. (\'medium\' is less than \'high\')')
+    );
+  });  
 });
 
 const SNYK_TEST_SUCCESS_TRUE = true;

--- a/snykTask/src/task-lib.ts
+++ b/snykTask/src/task-lib.ts
@@ -10,7 +10,7 @@ export const HTML_ATTACHMENT_TYPE = 'HTML_ATTACHMENT_TYPE';
 
 export const getOptionsToExecuteCmd = (taskArgs: TaskArgs): tr.IExecOptions => {
   return {
-    cwd: taskArgs.testDirectory,
+    // cwd: taskArgs.testDirectory,
     failOnStdErr: false,
     ignoreReturnCode: true,
   } as tr.IExecOptions;

--- a/snykTask/test/fixtures/high-vulnerabilities.json
+++ b/snykTask/test/fixtures/high-vulnerabilities.json
@@ -1,0 +1,13 @@
+{
+  "vulnerabilities": [
+    {
+      "severity": "critical"
+    },
+    {
+      "severity": "high"
+    }    
+  ],
+  "ok": true,
+  "dependencyCount": 0,
+  "org": "demo-applications"
+}

--- a/snykTask/test/fixtures/low-vulnerabilities.json
+++ b/snykTask/test/fixtures/low-vulnerabilities.json
@@ -1,0 +1,13 @@
+{
+  "vulnerabilities": [
+    {
+      "severity": "medium"
+    },
+    {
+      "severity": "low"
+    }    
+  ],
+  "ok": true,
+  "dependencyCount": 0,
+  "org": "demo-applications"
+}


### PR DESCRIPTION
As per #137, this adds support for a new parameter named `failOnThreshold`, which works as an additional control for detecting violations. 

An example use-case might be when you want to report on **all** detections to your project, but you only want to fail the build on critical thresholds. Previously, this wasn't possible as the severityThreshold was both the detection and failure threshold, whereas now we can split these out with a configuration such as

```
- task: SnykSecurityScan@1
  inputs:
    serviceConnectionEndpoint: 'mySnykToken'
    testType: 'app'
    failOnIssues: true
    failOnThreshold: 'critical'
    severityThreshold: 'low'
    monitorWhen: 'always'
```

As part of this change
- Additional tests around the new feature
- Split out validation logic from index->parseInputArgs into new method validate on TaskArgs - supports easier testing

Fixes #137