### PR TITLE
chore: secrets scanning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  prodsec: snyk/prodsec-orb@1.0
+  
 jobs:
   test:
     docker:
@@ -128,6 +131,11 @@ workflows:
   version: 2
   build_and_test:
     jobs:
+      - prodsec/secrets-scan:
+          name: Scan repository for secrets
+          context:
+            - snyk-bot-slack
+          channel: hammerhead-alerts
       - test
       - deploy_dev:
           requires:

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,1 @@
+# add false positives here

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.17.0
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
Adds secrets scanning to the repository. Developers should use the provided pre-commit hooks to prevent the secrets from reaching the repository. See [https://pre-commit.com/](https://pre-commit.com/)