### PR TITLE
chore: improve message when skipping .vsix copy in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ jobs:
               cp *.vsix prod-extension-artifact.vsix
               ls -la prod-extension-artifact.vsix
             else
-              echo "No .vsix files found to copy."
+              echo "No new version detected; skipping .vsix file copy step."
             fi
 
       - store_artifacts:


### PR DESCRIPTION
Ths PR provides more info when skipping the step in CI which handles `.vsix` file