### PR TITLE
fix: remove echo use

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "mock-fs": "^4.10.4",
         "prettier": "^2.3.1",
         "semantic-release": "^17.0.4",
+        "snyk-to-html": "^2.4.0",
         "tfx-cli": "^0.7.11",
         "ts-jest": "^26.3.0",
         "typescript": "^4.5.2"
@@ -3593,6 +3594,15 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/compare-func": {
@@ -9046,6 +9056,12 @@
       "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
       "dev": true
     },
+    "node_modules/lodash.isempty": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "integrity": "sha512-oKMuF3xEeqDltrGMfDxAPGIVMSSRv8tbRSODbrs4KGsRRLEhrW8N8Rd4DRgB2+621hY8A8XwwrTVhXWpxFvMzg==",
+      "dev": true
+    },
     "node_modules/lodash.ismatch": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
@@ -9062,6 +9078,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true
+    },
+    "node_modules/lodash.orderby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.orderby/-/lodash.orderby-4.6.0.tgz",
+      "integrity": "sha512-T0rZxKmghOOf5YPnn8EY5iLYeWCpZq8G41FfqoVHH5QDTAFaghJRmAdLiadEDq+ztgM2q5PjA+Z1fOwGrLgmtg==",
       "dev": true
     },
     "node_modules/lodash.unescape": {
@@ -9483,6 +9505,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "dev": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -14929,6 +14960,42 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/snyk-to-html": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/snyk-to-html/-/snyk-to-html-2.4.0.tgz",
+      "integrity": "sha512-dmemJJIE7IAdk7qsEh/lq8ZfyVkTjfGRTQD/YFPZ2IG1/ZtCUjOMLSP/nfv9Yjs5qQv3ozvDejfs1JQwnLQF+g==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.4.2",
+        "commander": "^4.1.1",
+        "debug": "^4.1.1",
+        "handlebars": "^4.7.7",
+        "lodash.isempty": "^4.4.0",
+        "lodash.orderby": "^4.6.0",
+        "marked": "^4.0.12",
+        "moment": "^2.29.4",
+        "source-map-support": "^0.5.16",
+        "uglify-js": "^3.15.1"
+      },
+      "bin": {
+        "snyk-to-html": "dist/index.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/snyk-to-html/node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -16195,7 +16262,6 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
       "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
       "dev": true,
-      "optional": true,
       "bin": {
         "uglifyjs": "bin/uglifyjs"
       },
@@ -19708,6 +19774,12 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true
     },
     "compare-func": {
       "version": "2.0.0",
@@ -23857,6 +23929,12 @@
       "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
       "dev": true
     },
+    "lodash.isempty": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "integrity": "sha512-oKMuF3xEeqDltrGMfDxAPGIVMSSRv8tbRSODbrs4KGsRRLEhrW8N8Rd4DRgB2+621hY8A8XwwrTVhXWpxFvMzg==",
+      "dev": true
+    },
     "lodash.ismatch": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
@@ -23873,6 +23951,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true
+    },
+    "lodash.orderby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.orderby/-/lodash.orderby-4.6.0.tgz",
+      "integrity": "sha512-T0rZxKmghOOf5YPnn8EY5iLYeWCpZq8G41FfqoVHH5QDTAFaghJRmAdLiadEDq+ztgM2q5PjA+Z1fOwGrLgmtg==",
       "dev": true
     },
     "lodash.unescape": {
@@ -24187,6 +24271,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
       "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
+      "dev": true
+    },
+    "moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
       "dev": true
     },
     "ms": {
@@ -28221,6 +28311,32 @@
         }
       }
     },
+    "snyk-to-html": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/snyk-to-html/-/snyk-to-html-2.4.0.tgz",
+      "integrity": "sha512-dmemJJIE7IAdk7qsEh/lq8ZfyVkTjfGRTQD/YFPZ2IG1/ZtCUjOMLSP/nfv9Yjs5qQv3ozvDejfs1JQwnLQF+g==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2",
+        "commander": "^4.1.1",
+        "debug": "^4.1.1",
+        "handlebars": "^4.7.7",
+        "lodash.isempty": "^4.4.0",
+        "lodash.orderby": "^4.6.0",
+        "marked": "^4.0.12",
+        "moment": "^2.29.4",
+        "source-map-support": "^0.5.16",
+        "uglify-js": "^3.15.1"
+      },
+      "dependencies": {
+        "marked": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+          "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+          "dev": true
+        }
+      }
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -29226,8 +29342,7 @@
       "version": "3.17.4",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
       "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "mock-fs": "^4.10.4",
     "prettier": "^2.3.1",
     "semantic-release": "^17.0.4",
+    "snyk-to-html": "^2.4.0",
     "tfx-cli": "^0.7.11",
     "ts-jest": "^26.3.0",
     "typescript": "^4.5.2"

--- a/snykTask/src/index.ts
+++ b/snykTask/src/index.ts
@@ -207,7 +207,7 @@ async function runSnykTest(
     snykTestExitCode === CLI_EXIT_CODE_SUCCESS
   ) {
     // pipe console json output to snykToHtml and file for subsequent conversion again
-    const echoToolRunner = tl.tool(snykToHtmlPath);
+    const snykToHtmlRunner = tl.tool(snykToHtmlPath);
     const snykCodeTestToolRunner = tl
       .tool(snykPath)
       .arg('code')
@@ -221,7 +221,7 @@ async function runSnykTest(
       .argIf(taskArgs.organization, `--org=${taskArgs.organization}`)
       .argIf(taskArgs.projectName, `--project-name=${projectNameArg}`)
       .line(taskArgs.additionalArguments)
-      .pipeExecOutputToTool(echoToolRunner, jsonReportOutputPath);
+      .pipeExecOutputToTool(snykToHtmlRunner, jsonReportOutputPath);
     await snykCodeTestToolRunner.exec(options);
   }
 

--- a/snykTask/src/index.ts
+++ b/snykTask/src/index.ts
@@ -142,6 +142,7 @@ async function showDirectoryListing(
 
 async function runSnykTest(
   snykPath: string,
+  snykToHtmlPath: string,
   taskArgs: TaskArgs,
   jsonReportOutputPath: string,
   snykToken: string,
@@ -205,7 +206,8 @@ async function runSnykTest(
     !fs.existsSync(jsonReportOutputPath) &&
     snykTestExitCode === CLI_EXIT_CODE_SUCCESS
   ) {
-    const echoToolRunner = tl.tool('echo');
+    // pipe console json output to snykToHtml and file for subsequent conversion again
+    const echoToolRunner = tl.tool(snykToHtmlPath);
     const snykCodeTestToolRunner = tl
       .tool(snykPath)
       .arg('code')
@@ -407,6 +409,7 @@ async function run() {
 
     const snykTestResult = await runSnykTest(
       snykPath,
+      snykToHtmlPath,
       taskArgs,
       jsonReportFullPath,
       snykToken,


### PR DESCRIPTION
- [X] follow CONTRIBUTING rules
- [X] Detailed description:
This fix PR switches `echo` to `snyk-to-html` command (which is always downloaded by extension and present). No change to execution behaviour because the json-to-html conversion will then subsequently be launched with the console json output.
- [X] Risk assessment: High
- [X] Non-breaking API
- [X] Test-units for use of snyk-to-html

1. Existent [getSnykDownloadInfo test-case](https://github.com/snyk/snyk-azure-pipelines-task/blob/8edb73ca90b72fad0e748d4e505f551141ca9535/snykTask/src/__tests__/install/index.test.ts#L20) tests download of multi-platform snyk-to-html binaries.
2. New `pipeExecOutputToTool` to `snyk-to-html` test-case on execution return code and verify content matches of its piped input written to its 2nd parameter file location.

- [X] No changes required at Gitbook

**User facing Documentation**
- [X] No other Gitbook PR documentation required
- [X] commit to prefix with fix:
- [X] No CHANGELOG.md present

**Testing**
- [X] testcases must pass in configured CI Job