### PR TITLE
fix: remove use of echo for snyk code flow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  prodsec: snyk/prodsec-orb@1.0
+  prodsec: snyk/prodsec-orb@1.1
 
 jobs:
   test:

--- a/.snyk
+++ b/.snyk
@@ -10,6 +10,6 @@ ignore:
   SNYK-JS-INFLIGHT-6095116:
     - '*':
         reason: No upgrade available
-        expires: 2024-03-01T00:00:00.000Z
+        expires: 2024-06-01T00:00:00.000Z
         created: 2023-12-04T08:42:17.557Z
 patch: {}

--- a/snykTask/src/__tests__/task-lib.test.ts
+++ b/snykTask/src/__tests__/task-lib.test.ts
@@ -226,6 +226,44 @@ describe('getOptionsForSnykToHtml', () => {
   });
 });
 
+describe('generateSnykCodeResultsWithoutIssues sends console output to file', () => {
+  it('asserts stdout json matches file content', async () => {
+    const taskNameForAnalytics = 'AZURE_PIPELINES';
+    const version = '1.2.3';
+    const codeTestJsonPath = 'snykTask/test/fixtures/code-test-no-issues.json';
+    const taskArgs: TaskArgs = new TaskArgs({
+      failOnIssues: true,
+    });
+    taskArgs.testDirectory = tempFolder;
+    const inputCodeTestJsonPath = path.resolve(tempFolder, 'tmp.json');
+    const pipedCodeTestJsonPath = path.resolve(tempFolder, 'pipedtmp.json');
+    fs.copyFileSync(codeTestJsonPath, inputCodeTestJsonPath);
+    const options: tr.IExecOptions = getOptionsToExecuteSnykCLICommand(
+      taskArgs,
+      taskNameForAnalytics,
+      version,
+      'fake-token',
+    );
+
+    // mock behaviour of a cmd sending sample printed console output to file
+    const mockPipeToFileRunner = tl
+      .tool(tl.which('cat', true))
+      .arg(inputCodeTestJsonPath)
+    const snykCodeTestResult = await mockPipeToFileRunner.execSync(options);
+    tl.writeFile(pipedCodeTestJsonPath, snykCodeTestResult.stdout);
+
+    expect(
+      fs.readFileSync(inputCodeTestJsonPath, { encoding: 'utf8', flag: 'r' }),
+    ).toEqual(
+      // snykCodeTestResult.stdout
+      fs.readFileSync(pipedCodeTestJsonPath, {
+        encoding: 'utf8',
+        flag: 'r',
+      }),
+    );
+  });
+});
+
 test('formatDate gives format we want for the report filename', () => {
   const timestampMillis = 1590174610000; // arbitrary timestamp in ms since epoch
   const d = new Date(timestampMillis);

--- a/snykTask/src/__tests__/task-lib.test.ts
+++ b/snykTask/src/__tests__/task-lib.test.ts
@@ -248,39 +248,6 @@ describe('getOptionsForSnykToHtml', () => {
 });
 
 describe('generateSnykCodeResultsWithoutIssues sends console output to file', () => {
-  it('asserts stdout json matches file content', async () => {
-    const taskNameForAnalytics = 'AZURE_PIPELINES';
-    const version = '1.2.3';
-    const codeTestJsonPath = 'snykTask/test/fixtures/code-test-no-issues.json';
-    const taskArgs: TaskArgs = new TaskArgs({
-      failOnIssues: true,
-    });
-    taskArgs.testDirectory = tempFolder;
-    const inputCodeTestJsonPath = path.resolve(tempFolder, 'tmp.json');
-    const pipedCodeTestJsonPath = path.resolve(tempFolder, 'pipedtmp.json');
-    fs.copyFileSync(codeTestJsonPath, inputCodeTestJsonPath);
-    const options: tr.IExecOptions = getOptionsToExecuteSnykCLICommand(
-      taskArgs,
-      taskNameForAnalytics,
-      version,
-      'fake-token',
-    );
-
-    // mock behaviour of a cmd sending sample printed console output to file
-    const mockPipeToFileRunner = tl
-      .tool(tl.which('cat', true))
-      .arg(inputCodeTestJsonPath);
-    const snykCodeTestResult = await mockPipeToFileRunner.execSync(options);
-    tl.writeFile(pipedCodeTestJsonPath, snykCodeTestResult.stdout);
-
-    expect(snykCodeTestResult.stdout).toEqual(
-      fs.readFileSync(pipedCodeTestJsonPath, {
-        encoding: 'utf8',
-        flag: 'r',
-      }),
-    );
-  });
-
   it('basic test for generateSnykCodeResultsWithoutIssues()', async () => {
     const taskArgs: TaskArgs = new TaskArgs({
       failOnIssues: true,

--- a/snykTask/src/__tests__/task-lib.test.ts
+++ b/snykTask/src/__tests__/task-lib.test.ts
@@ -286,8 +286,15 @@ describe('generateSnykCodeResultsWithoutIssues sends console output to file', ()
       failOnIssues: true,
     });
 
-    taskArgs.testDirectory = path.join(__dirname, '..', '..','test','fixtures','golang-no-code-issues')
-    console.debug(taskArgs.testDirectory)
+    taskArgs.testDirectory = path.join(
+      __dirname,
+      '..',
+      '..',
+      'test',
+      'fixtures',
+      'golang-no-code-issues',
+    );
+    console.debug(taskArgs.testDirectory);
 
     const outputPath = path.join(
       tempFolder,

--- a/snykTask/src/__tests__/task-lib.test.ts
+++ b/snykTask/src/__tests__/task-lib.test.ts
@@ -286,6 +286,9 @@ describe('generateSnykCodeResultsWithoutIssues sends console output to file', ()
       failOnIssues: true,
     });
 
+    taskArgs.testDirectory = path.join(__dirname, '..', '..','test','fixtures','golang-no-code-issues')
+    console.debug(taskArgs.testDirectory)
+
     const outputPath = path.join(
       tempFolder,
       'generateSnykCodeResultsWithoutIssues_test.json',

--- a/snykTask/src/__tests__/task-lib.test.ts
+++ b/snykTask/src/__tests__/task-lib.test.ts
@@ -252,10 +252,7 @@ describe('generateSnykCodeResultsWithoutIssues sends console output to file', ()
     const snykCodeTestResult = await mockPipeToFileRunner.execSync(options);
     tl.writeFile(pipedCodeTestJsonPath, snykCodeTestResult.stdout);
 
-    expect(
-      fs.readFileSync(inputCodeTestJsonPath, { encoding: 'utf8', flag: 'r' }),
-    ).toEqual(
-      // snykCodeTestResult.stdout
+    expect(snykCodeTestResult.stdout).toEqual(
       fs.readFileSync(pipedCodeTestJsonPath, {
         encoding: 'utf8',
         flag: 'r',

--- a/snykTask/src/__tests__/task-lib.test.ts
+++ b/snykTask/src/__tests__/task-lib.test.ts
@@ -320,6 +320,8 @@ describe('generateSnykCodeResultsWithoutIssues sends console output to file', ()
     const actualFileContent = fs.readFileSync(outputPath);
     const obj = JSON.parse(actualFileContent.toString());
     expect(obj).not.toBeNull();
+
+    console.debug(obj);
   });
 });
 

--- a/snykTask/src/__tests__/task-lib.test.ts
+++ b/snykTask/src/__tests__/task-lib.test.ts
@@ -248,7 +248,7 @@ describe('generateSnykCodeResultsWithoutIssues sends console output to file', ()
     // mock behaviour of a cmd sending sample printed console output to file
     const mockPipeToFileRunner = tl
       .tool(tl.which('cat', true))
-      .arg(inputCodeTestJsonPath)
+      .arg(inputCodeTestJsonPath);
     const snykCodeTestResult = await mockPipeToFileRunner.execSync(options);
     tl.writeFile(pipedCodeTestJsonPath, snykCodeTestResult.stdout);
 

--- a/snykTask/src/__tests__/task-lib.test.ts
+++ b/snykTask/src/__tests__/task-lib.test.ts
@@ -20,6 +20,10 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import * as fse from 'fs-extra';
+import { generateSnykCodeResultsWithoutIssues } from '../index';
+import { getSnykDownloadInfo, downloadExecutable } from '../install';
+
+jest.setTimeout(120_000);
 
 import stream = require('stream');
 
@@ -33,12 +37,29 @@ import {
   doVulnerabilitiesExistForFailureThreshold,
 } from '../task-lib';
 import { TaskArgs } from '../task-args';
+import { execSync } from 'child_process';
 
 let tempFolder = '';
+let snykCliPath = '';
+
+function getTestToken(): string {
+  if (process.env.SNYK_TOKEN === undefined) {
+    const output = execSync(snykCliPath + ' config get api');
+    return output.toString().trim();
+  }
+
+  return process.env.SNYK_TOKEN;
+}
+
 beforeAll(async () => {
   tempFolder = await fse.promises.mkdtemp(
     path.resolve(os.tmpdir(), 'snyk-azure-pipelines-task-test'),
   );
+
+  const dlInfo = getSnykDownloadInfo(tl.getPlatform());
+  await downloadExecutable(tempFolder, dlInfo.snyk);
+
+  snykCliPath = path.resolve(tempFolder, dlInfo.snyk.filename);
 });
 
 afterEach(() => {
@@ -258,6 +279,37 @@ describe('generateSnykCodeResultsWithoutIssues sends console output to file', ()
         flag: 'r',
       }),
     );
+  });
+
+  it('basic test for generateSnykCodeResultsWithoutIssues()', async () => {
+    const taskArgs: TaskArgs = new TaskArgs({
+      failOnIssues: true,
+    });
+
+    const outputPath = path.join(
+      tempFolder,
+      'generateSnykCodeResultsWithoutIssues_test.json',
+    );
+    const testToken = getTestToken();
+
+    expect(fs.existsSync(outputPath)).toBeFalsy();
+
+    // call method under test
+    await generateSnykCodeResultsWithoutIssues(
+      snykCliPath,
+      taskArgs,
+      outputPath,
+      testToken,
+    );
+
+    // check expected output
+    const actualFileStat = fs.statSync(outputPath);
+    expect(actualFileStat.isFile()).toBeTruthy();
+    expect(actualFileStat.size).toBeGreaterThan(0);
+
+    const actualFileContent = fs.readFileSync(outputPath);
+    const obj = JSON.parse(actualFileContent.toString());
+    expect(obj).not.toBeNull();
   });
 });
 

--- a/snykTask/src/index.ts
+++ b/snykTask/src/index.ts
@@ -172,6 +172,10 @@ export async function generateSnykCodeResultsWithoutIssues(
   const snykCodeTestResult: tr.IExecSyncResult =
     snykCodeTestToolRunner.execSync(options);
   tl.writeFile(jsonReportOutputPath, snykCodeTestResult.stdout);
+
+  if (isDebugMode()) {
+    console.log(snykCodeTestResult);
+  }
 }
 
 async function runSnykTest(

--- a/snykTask/src/index.ts
+++ b/snykTask/src/index.ts
@@ -140,7 +140,7 @@ async function showDirectoryListing(
   }
 }
 
-async function generateSnykCodeResultsWithoutIssues(
+export async function generateSnykCodeResultsWithoutIssues(
   snykPath: string,
   taskArgs: TaskArgs,
   jsonReportOutputPath: string,

--- a/snykTask/src/index.ts
+++ b/snykTask/src/index.ts
@@ -140,7 +140,7 @@ async function showDirectoryListing(
   }
 }
 
-async function runSnykCodeTest(
+async function generateSnykCodeResultsWithoutIssues(
   snykPath: string,
   taskArgs: TaskArgs,
   jsonReportOutputPath: string,
@@ -233,7 +233,7 @@ async function runSnykTest(
   }
   const snykOutput: SnykOutput = { code: code, message: errorMsg };
 
-  // handle bug in snyk CLI for code test, when --json-file-output is specified
+  // handle inconsistency in snyk CLI for code test, when --json-file-output is specified
   // and the test results in no issues found, no JSON is produced when it should still be
   // just with an empty set of issues
   if (
@@ -241,7 +241,12 @@ async function runSnykTest(
     !fs.existsSync(jsonReportOutputPath) &&
     snykTestExitCode === CLI_EXIT_CODE_SUCCESS
   ) {
-    await runSnykCodeTest(snykPath, taskArgs, jsonReportOutputPath, snykToken);
+    await generateSnykCodeResultsWithoutIssues(
+      snykPath,
+      taskArgs,
+      jsonReportOutputPath,
+      snykToken,
+    );
   }
 
   removeRegexFromFile(

--- a/snykTask/src/index.ts
+++ b/snykTask/src/index.ts
@@ -140,6 +140,40 @@ async function showDirectoryListing(
   }
 }
 
+async function runSnykCodeTest(
+  snykPath: string,
+  taskArgs: TaskArgs,
+  jsonReportOutputPath: string,
+  snykToken: string,
+) {
+  const projectNameArg = taskArgs.getProjectNameParameter();
+
+  const options = getOptionsToExecuteSnykCLICommand(
+    taskArgs,
+    taskNameForAnalytics,
+    taskVersion,
+    snykToken,
+  );
+
+  const snykCodeTestToolRunner = tl
+    .tool(snykPath)
+    .arg('code')
+    .arg('test')
+    .arg('--json')
+    .argIf(
+      taskArgs.codeSeverityThreshold,
+      `--severity-threshold=${taskArgs.codeSeverityThreshold}`,
+    )
+    .argIf(taskArgs.ignoreUnknownCA, `--insecure`)
+    .argIf(taskArgs.organization, `--org=${taskArgs.organization}`)
+    .argIf(taskArgs.projectName, `--project-name=${projectNameArg}`)
+    .line(taskArgs.additionalArguments);
+
+  const snykCodeTestResult: tr.IExecSyncResult =
+    snykCodeTestToolRunner.execSync(options);
+  tl.writeFile(jsonReportOutputPath, snykCodeTestResult.stdout);
+}
+
 async function runSnykTest(
   snykPath: string,
   taskArgs: TaskArgs,
@@ -199,28 +233,15 @@ async function runSnykTest(
   }
   const snykOutput: SnykOutput = { code: code, message: errorMsg };
 
-  // handle snyk code no-issues-found non-existent json by rerunning --json stdout to piped file
+  // handle bug in snyk CLI for code test, when --json-file-output is specified
+  // and the test results in no issues found, no JSON is produced when it should still be
+  // just with an empty set of issues
   if (
     taskArgs.testType == TestType.CODE &&
     !fs.existsSync(jsonReportOutputPath) &&
     snykTestExitCode === CLI_EXIT_CODE_SUCCESS
   ) {
-    const echoToolRunner = tl.tool('echo');
-    const snykCodeTestToolRunner = tl
-      .tool(snykPath)
-      .arg('code')
-      .arg('test')
-      .arg('--json')
-      .argIf(
-        taskArgs.codeSeverityThreshold,
-        `--severity-threshold=${taskArgs.codeSeverityThreshold}`,
-      )
-      .argIf(taskArgs.ignoreUnknownCA, `--insecure`)
-      .argIf(taskArgs.organization, `--org=${taskArgs.organization}`)
-      .argIf(taskArgs.projectName, `--project-name=${projectNameArg}`)
-      .line(taskArgs.additionalArguments)
-      .pipeExecOutputToTool(echoToolRunner, jsonReportOutputPath);
-    await snykCodeTestToolRunner.exec(options);
+    await runSnykCodeTest(snykPath, taskArgs, jsonReportOutputPath, snykToken);
   }
 
   removeRegexFromFile(

--- a/snykTask/src/install/index.ts
+++ b/snykTask/src/install/index.ts
@@ -73,7 +73,7 @@ export async function downloadExecutable(
   const doDownload = () =>
     new Promise<void>((resolve, reject) => {
       https.get(executable.downloadUrl, (response) => {
-        response.on('end', () => resolve());
+        fileWriter.on('close', () => resolve());
         response.on('error', (err) => {
           console.error(
             `Download of ${executable.filename} failed: ${err.message}`,

--- a/snykTask/test/fixtures/golang-no-code-issues/go.mod
+++ b/snykTask/test/fixtures/golang-no-code-issues/go.mod
@@ -1,0 +1,5 @@
+module app
+
+go 1.12
+
+require github.com/lib/pq v1.1.1

--- a/snykTask/test/fixtures/golang-no-code-issues/go.sum
+++ b/snykTask/test/fixtures/golang-no-code-issues/go.sum
@@ -1,0 +1,1 @@
+github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=

--- a/snykTask/test/fixtures/golang-no-code-issues/main.go
+++ b/snykTask/test/fixtures/golang-no-code-issues/main.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+	// nothing to see here
+}


### PR DESCRIPTION
- [X] follow CONTRIBUTING rules
- [X] Detailed description:
This fix PR removes use of the system `echo` command which is causing an error running on runners that don't have this command available.  [Here](https://snyk.zendesk.com/agent/tickets/70704) is a ticket describing a customer issue. 
- [X] Risk assessment: High
- [X] Non-breaking API
- [X] Test-units
- [X] No changes required at Gitbook

**User facing Documentation**
- [X] No other Gitbook PR documentation required
- [X] commit to prefix with fix:
- [X] No CHANGELOG.md present

**Testing**
- [X] testcases must pass in configured CI Job