### PR TITLE
fix: Detect app vulnerabilities in container scans

### DIFF
--- a/snykTask/src/__tests__/task-lib.test.ts
+++ b/snykTask/src/__tests__/task-lib.test.ts
@@ -184,6 +184,16 @@ test('finds no issues in code test of high threshold', () => {
   expect(itemsFound).toBe(false);
 });
 
+test('finds issues in container test of high threshold', () => {
+  const fixturePath = 'snykTask/test/fixtures/container-test-error-issues.json';
+  const itemsFound = doVulnerabilitiesExistForFailureThreshold(
+    fixturePath,
+    'high',
+  );
+
+  expect(itemsFound).toBe(true);
+});
+
 test('getOptionsToExecuteSnykCLICommand builds IExecOptions like we need it', () => {
   const taskNameForAnalytics = 'AZURE_PIPELINES';
   const version = '1.2.3';

--- a/snykTask/src/task-lib.ts
+++ b/snykTask/src/task-lib.ts
@@ -191,6 +191,13 @@ function hasMatchingVulnerabilities(project: any, thresholdOrdinal: number) {
       return true;
     }
   }
+  if (project['applications']) {
+    for (const application of project['applications']) {
+      if (hasMatchingVulnerabilities(application, thresholdOrdinal)) {
+        return true;
+      }
+    }
+  }
   return false;
 }
 

--- a/snykTask/test/fixtures/container-test-error-issues.json
+++ b/snykTask/test/fixtures/container-test-error-issues.json
@@ -1,0 +1,13 @@
+{
+  "vulnerabilities": [],
+  "ok": true,
+  "applications": [
+    {
+      "vulnerabilities": [
+        {
+          "severity": "critical"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
I have found that my container scan correctly prints out that there is a critical vulnerability, but then the build happily passes:

```

Tested 4 projects, 1 contained vulnerable paths.
...
no vulnerabilities of at least 'critical' severity were detected, not failing build
```

Running the scan locally I could see the output doesn't put the vulnerabilities at the top level of the JSON output
and so they are totally ignored. This change means that we look through all the application vulnerabilities also if they exist.