### PR TITLE
refactor: do not show the snyk-report-tab on build results that do not contain the snyk task

### DIFF
--- a/vss-extension-dev.json
+++ b/vss-extension-dev.json
@@ -81,7 +81,8 @@
       "targets": ["ms.vss-build-web.build-results-view"],
       "properties": {
         "name": "Snyk Report",
-        "uri": "ui/snyk-report-tab.html"
+        "uri": "ui/snyk-report-tab.html",
+        "supportsTasks": ["826d5fe9-3983-4643-b918-487964d7cc87"]
       }
     },
     {

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -81,7 +81,8 @@
       "targets": ["ms.vss-build-web.build-results-view"],
       "properties": {
         "name": "Snyk Report",
-        "uri": "ui/snyk-report-tab.html"
+        "uri": "ui/snyk-report-tab.html",
+        "supportsTasks": ["826d5fe9-3983-4643-b918-487964d7cc87"]
       }
     },
     {


### PR DESCRIPTION
Currently the "Snyk Report" tab shows on all build results, even if the build pipeline does not actually use the Snyk task. If the task is never run, the tab renders nothing and just clutters the build results.

This change restricts the tab so that it only show for builds that actually ran the Snyk task.


![image](https://github.com/user-attachments/assets/a25eab26-e90b-4c13-a25e-5d8edff7f6bd)
_^ this build pipeline does not contain the Snyk task, but it shows anyway._
