### PR TITLE
fix: removes minimumAgentVersion constraint

### DIFF
--- a/snykTask/task.json
+++ b/snykTask/task.json
@@ -173,7 +173,6 @@
       "groupName": "advanced"
     }
   ],
-  "minimumAgentVersion": "3.232.1",
   "execution": {
     "Node10": {
       "target": "./dist/index.js"


### PR DESCRIPTION
The minimum version constraint represents a breaking change for customers running on the self hosted agents which are not able to upgrade to v3.232.1+

Based on the documentaton:
> If several handlers are specified in the task.json file, the highest one will be selected from handlers that are available on the certain agent. For example, if Node10, Node16, and Node20_1 handlers are specified in the task.json file, and an old version of the agent (that is going to execute the task) has Node (version 6), Node10, and Node16 handlers, then the Node16 handler will be used. At the same time, the same agent will fail to execute the task if the Node20_1 handler only is specified in the task.json file. Therefore you should specify minimumAgentVersion.
https://github.com/microsoft/azure-pipelines-tasks/blob/master/docs/migrateNode20.md#specify-minimumagentversion