### PR TITLE
fix: make JavaScript usable in Snyk Report tab (CLI-268)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ snykTask/coverage
 .eslintcache
 .ops
 ops/deploy/dist
+.dccache
+build/
+.vscode/

--- a/ui/enhancer/snyk-report.ts
+++ b/ui/enhancer/snyk-report.ts
@@ -183,7 +183,27 @@ export class SnykReportTab extends Controls.BaseControl {
   };
 
   private fillReportIFrameContent = (content: string): void => {
-    (document.getElementById('iframeID') as HTMLDivElement).innerHTML = content;
+    // Remove existing iframe and create a fresh one to avoid JS variable redeclaration issues
+    const oldIframe = document.getElementById('snyk-report');
+    if (oldIframe?.parentNode) {
+      oldIframe.parentNode.removeChild(oldIframe);
+    }
+
+    // Create new iframe
+    const newIframe = document.createElement('iframe');
+    newIframe.id = 'snyk-report';
+    newIframe.className = 'content';
+
+    // Add the new iframe to the document
+    document.body.appendChild(newIframe);
+
+    // Write content to the fresh iframe
+    const doc = newIframe.contentDocument || newIframe.contentWindow?.document;
+    if (doc) {
+      doc.open();
+      doc.write(content);
+      doc.close();
+    }
   };
 }
 

--- a/ui/snyk-report-tab.html
+++ b/ui/snyk-report-tab.html
@@ -27,8 +27,9 @@
         height: 100%;
         overflow: auto;
       }
-      .iframeContainer {
+      .content {
         overflow: auto;
+        min-width: 100%;
         min-height: 100%;
       }
       .list {
@@ -84,11 +85,15 @@
     <script type="text/javascript">
       VSS.init();
     </script>
-    <h2>Reports:</h2>
-    <ul id="reportList" class="list"></ul>
-    <div class="iframeContainer">
-      <div id="iframeID" class="iframe"></div>
+    <div class="header">
+      <h2>Reports:</h2>
     </div>
-    <div id="snyk-report" class="container"></div>
+    <ul id="reportList" class="list"></ul>
+    <iframe
+      id="snyk-report"
+      class="content"
+      sandbox="allow-scripts allow-same-origin allow-forms allow-modals allow-popups allow-presentation"
+      src="about:blank"
+    ></iframe>
   </body>
 </html>


### PR DESCRIPTION
[CLI-268](https://snyksec.atlassian.net/browse/CLI-268)

**Problem:**
After running a build, the Snyk Report tab includes a report with `Data Flow` and `Fix Analysis` tabs that do nothing when clicked. The browser console shows the following error message:
```
snyk-report-tab.html:1 Uncaught ReferenceError: toggleCardView is not defined
    at HTMLSpanElement.onclick (snyk-report-tab.html:1:1)
```
(`toggleCardView` is a JS function in the included `<script>` section of the report)

**Solution:**
After modifying the HTML template to use an `<iframe>`, and adjusting the backend logic for filling the iframe, JavaScript is working as expected.

**How to Test:**
Navigate to [this build](https://dev.azure.com/snyk-dev/goof/_build/results?buildId=811&view=results) in dev and compare the two Snyk Report tabs. The one on the left is production, and the one on the right is this PR.

[CLI-268]: https://snyksec.atlassian.net/browse/CLI-268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ