### PR TITLE
chore(ci): upgrade circleCI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
 
   deploy_dev:
     docker:
-      - image: circleci/node:lts
+      - image: cimg/node:lts
         environment:
           DEV_AZ_EXTENSION_ID: 'dev-security-scan-test'
           DEV_AZ_EXTENSION_NAME: 'Dev - Snyk Security Scan'


### PR DESCRIPTION
Switch from legacy CircleCI convenience images to new ones. 

Further reading:
* https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034/16
* https://circleci.com/developer/images/image/cimg/node