### PR TITLE
fix: ensure report is not truncated

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Run `npm run build` in the root folder. All tooling prerequisites (Node.js, Type
 ### Test and Run
 Unit tests can be run via `npm run test:unit` command.
 
-To run the code, a GitHub PR against `develop` should be raised with the committed code to the branch PR. The PR runs deployment script with deploy to development environment. The script builds the code that's added as part of your change and installs it in Azure DevOps organization as an extension that can be added to run a pipeline.
+To run the code, a GitHub PR against `master` should be raised with the committed code to the branch PR. The PR runs deployment script with deploy to development environment. The script builds the code that's added as part of your change and installs it in Azure DevOps organization as an extension that can be added to run a pipeline.
 
 ### Local debugging
 
@@ -42,7 +42,7 @@ A number of environment variable are required for debugging, here's an example l
 ```
 
 ## Release
-The release process is fully-automated: all you need to do is create a PR to merge `develop` into `master` and call the PR `Merge develop into master for release`.
+The release process is fully-automated: all you need to do is create a PR to merge into `master`.
 
 ## Contributor Agreement
 A pull-request will only be considered for merging into the upstream codebase after you have signed our [contributor agreement](https://github.com/snyk/snyk-azure-pipelines-task/blob/master/Contributor-Agreement.md), assigning us the rights to the contributed code and granting you a license to use it in return. If you submit a pull request, you will be prompted to review and sign the agreement with one click (we use [CLA assistant](https://cla-assistant.io/)).

--- a/ui/snyk-report-tab.html
+++ b/ui/snyk-report-tab.html
@@ -22,11 +22,6 @@
       body {
         height: 100%;
       }
-      .container {
-        width: 100%;
-        height: 100%;
-        overflow: auto;
-      }
       .iframeContainer {
         overflow: auto;
         min-height: 100%;
@@ -89,6 +84,6 @@
     <div class="iframeContainer">
       <div id="iframeID" class="iframe"></div>
     </div>
-    <div id="snyk-report" class="container"></div>
+    <div id="snyk-report"></div>
   </body>
 </html>

--- a/ui/snyk-report-tab.html
+++ b/ui/snyk-report-tab.html
@@ -24,7 +24,6 @@
       }
       .iframeContainer {
         overflow: auto;
-        min-height: 100%;
       }
       .list {
         line-height: 2.5;


### PR DESCRIPTION
## What does this do?

The last part of the report was being cut off because of some styling issues:
- the `iframeContainer` min-height property was being set at 100% which translate to at least 100vh (inherited by the iframe body content). This combined with the offset for the report list would result in the last part of the content not being visible. Removing this `min-height` would make the whole report document scrollable.
- removed the `container` class from the `snyk-report` since it was taking space from the actual report content, and the element seemed to only be used to mount the extension.

## Other
- https://snyksec.atlassian.net/browse/CLI-659