### PR TITLE
fix: make fix analysis accessible

### DIFF
--- a/ui/enhancer/snyk-report.ts
+++ b/ui/enhancer/snyk-report.ts
@@ -179,12 +179,26 @@ export class SnykReportTab extends Controls.BaseControl {
       .then((content) => {
         const data = new TextDecoder('utf-8').decode(new DataView(content));
         this.fillReportIFrameContent(data);
+        this.registerReportScripts();
       });
   };
 
   private fillReportIFrameContent = (content: string): void => {
     (document.getElementById('iframeID') as HTMLDivElement).innerHTML = content;
   };
+
+  private registerReportScripts() {
+    const target = document.getElementById('iframeID');
+    const scripts = target?.getElementsByTagName('script');
+    if (scripts && scripts.length > 0) {
+      for (const script of scripts) {
+        const newScript = document.createElement('script');
+        newScript.textContent = script.textContent;
+        document.body.appendChild(newScript);
+        target?.removeChild(script);
+      }
+    }
+  }
 }
 
 SnykReportTab.enhance(SnykReportTab, $('#snyk-report'), {});


### PR DESCRIPTION
## Why?

The `Fix Analysis` tab is not doing anything when clicked. This is because the JavaScript functions defined inside the <script> tag of  the report's HTML is not being executed (since it's loaded dynamically together with the rest of the report, [the DOM is not going to execute it](https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML#security_considerations)). 

## How?

Compared to #209, this solution just gets the script elements from the report HTML and appends them as children to the document body. 

## Related

- [CLI-268](https://snyksec.atlassian.net/browse/CLI-268)
- [CLI-641](https://snyksec.atlassian.net/browse/CLI-641)


[CLI-268]: https://snyksec.atlassian.net/browse/CLI-268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLI-641]: https://snyksec.atlassian.net/browse/CLI-641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ