### PR TITLE
chore: add preview deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,44 @@ jobs:
           command: |
             node ./ops/deploy/dist/run-test-pipelines.js
 
+  deploy_preview:
+    docker:
+      - image: cimg/node:lts
+        environment:
+          AZ_EXTENSION_ID: 'preview-snyk-security-scan'
+          AZ_EXTENSION_NAME: '(Preview) Snyk Security Scan'
+          AZ_TASK_NAME: 'PreviewSnykSecurityScan'
+          AZ_TASK_FRIENDLY_NAME: '(Preview) Snyk Security Scan'
+          AZ_PUBLISHER: 'Snyk'
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - run:
+          name: Show Node Environment
+          command: |
+            node --version
+            npm --version
+      - run:
+          name: Run Build
+          command: |
+            npm run build:clean
+      - run:
+          name: Build and Deploy to Preview Environment
+          command: |
+            export AZURE_DEVOPS_EXT_PAT=$PROD_AZURE_DEVOPS_EXT_PAT
+
+            echo PREVIEW_AZ_EXTENSION_ID: $AZ_EXTENSION_ID
+            echo PREVIEW_AZ_EXTENSION_NAME: $AZ_EXTENSION_NAME
+            echo PREVIEW_AZ_TASK_NAME: $AZ_TASK_NAME
+            echo PREVIEW_AZ_PUBLISHER: $AZ_PUBLISHER
+
+            npm run deploy:compile
+
+            VERSION=$(date +"%Y.%-m.%-d%H%M")
+            echo "Deploying to Preview: ${VERSION}"
+
+            chmod +x scripts/ci-deploy-preview.sh
+            scripts/ci-deploy-preview.sh $VERSION
   deploy_prod:
     docker:
       - image: circleci/node:lts
@@ -159,9 +197,24 @@ workflows:
           filters:
             branches:
               ignore: master
+
       - deploy_prod:
           requires:
             - test
           filters:
             branches:
               only: master
+  manual_approval:
+    jobs:
+      - approve-preview-deployment:
+          name: 'Deploy the branch as Preview?'
+          type: approval
+          filters:
+            branches:
+              ignore: master
+      - deploy_preview:
+          requires:
+            - 'Deploy the branch as Preview?'
+          filters:
+            branches:
+              ignore: master

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,7 +23,7 @@ module.exports = {
   // },
   env: {
     node: true,
-    es6: true,
+    es2020: true,
     'jest/globals': true,
   },
   plugins: ['jest', '@typescript-eslint'],

--- a/scripts/ci-deploy-preview.sh
+++ b/scripts/ci-deploy-preview.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+#
+# Copyright 2025 Snyk Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This script publish the extension to Marketplace. Preview Production deployment.
+# Arguments:
+# $1 - Extension version
+
+set -e
+
+# Install tfx
+echo "Installing tfx-cli globally..."
+sudo npm install -g tfx-cli@0.7.11
+
+# Build project
+"${PWD}/scripts/ci-build.sh" "prod"
+
+# Handle arguments
+AZ_EXT_NEW_VERSION="$1"
+
+# Updating version in task.json file
+node "${PWD}/scripts/ci-update-task-json-preview.js" ${AZ_EXT_NEW_VERSION}
+
+# Override version
+OVERRIDE_JSON="{ \"id\": \"${AZ_EXTENSION_ID}\", \"name\": \"${AZ_EXTENSION_NAME}\", \"version\": \"${AZ_EXT_NEW_VERSION}\", \"public\": true }"
+
+# Echo ENVs and publish extension
+echo "Publishing preview extension to Azure DevOps Marketplace..."
+echo "Version: ${AZ_EXT_NEW_VERSION}"
+echo "Extension ID: ${AZ_EXTENSION_ID}"
+echo "Publisher: ${AZ_PUBLISHER}"
+echo "Override JSON: ${OVERRIDE_JSON}"
+
+tfx extension publish --manifest-globs vss-extension-preview.json \
+--version $AZ_EXT_NEW_VERSION \
+--extension-id $AZ_EXTENSION_ID \
+--publisher $AZ_PUBLISHER \
+--override $OVERRIDE_JSON \
+--token $AZURE_DEVOPS_EXT_PAT
+
+publish_exit_code=$?
+if [[ publish_exit_code -eq 0 ]]; then
+  echo "Preview Extension published: ${AZ_EXT_NEW_VERSION}"
+else
+  echo "Preview Extension failed to pubish with exit code ${publish_exit_code}"
+  exit ${publish_exit_code}
+fi

--- a/scripts/ci-update-task-json-preview.js
+++ b/scripts/ci-update-task-json-preview.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 Snyk Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const fs = require('fs');
+
+console.log('Replacing version snykTask/task.json file...');
+// Get version from argument
+const version = process.argv[2];
+
+const taskId = process.env.PREVIEW_AZ_TASK_ID;
+const taskName = process.env.AZ_TASK_NAME;
+const taskFriendlyName = process.env.AZ_TASK_FRIENDLY_NAME;
+
+if (!version.match(/^\d{4}\.\d{1,2}\.\d{1,2}\d{4}$/)) {
+  console.log('Invalid version: ', version);
+  process.exitCode = 1;
+  process.exit();
+}
+
+// Break version and create the JSON to be replaced
+const metaVersion = version.split('.');
+const taskVersion = {
+  Major: metaVersion[0],
+  Minor: metaVersion[1],
+  Patch: metaVersion[2],
+};
+
+console.log('taskVersion: ', taskVersion);
+
+// Replace version in the snykTask/task.json file
+const filePath = './snykTask/task.json';
+const taskJSON_File = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+
+taskJSON_File['id'] = taskId;
+taskJSON_File['name'] = taskName;
+taskJSON_File['friendlyName'] = taskFriendlyName;
+taskJSON_File['version'] = taskVersion;
+
+fs.writeFileSync(filePath, JSON.stringify(taskJSON_File, null, 2), 'utf8');
+
+console.log(
+  'Version replaced in snykTask/task.json file with: ',
+  taskJSON_File['version'],
+);

--- a/vss-extension-preview.json
+++ b/vss-extension-preview.json
@@ -1,0 +1,88 @@
+{
+  "manifestVersion": 1,
+  "id": "preview-snyk-security-scan",
+  "name": "(Preview) Snyk Security Scan",
+  "version": "0.0.0",
+  "publisher": "Snyk",
+  "targets": [
+    {
+      "id": "Microsoft.VisualStudio.Services"
+    }
+  ],
+  "description": "Snyk scan for open source vulnerabilities",
+  "categories": ["Azure Pipelines"],
+  "icons": {
+    "default": "images/extension-icon.png"
+  },
+  "scopes": ["vso.build_execute"],
+  "files": [
+    {
+      "path": "snykTask"
+    },
+    {
+      "path": "scripts/dist",
+      "addressable": true,
+      "packagePath": "scripts"
+    },
+    {
+      "path": "images",
+      "addressable": true,
+      "packagePath": "img"
+    },
+    {
+      "path": "ui/snyk-report-tab.html",
+      "addressable": true
+    },
+    {
+      "path": "node_modules/vss-web-extension-sdk/lib",
+      "addressable": true,
+      "packagePath": "lib"
+    },
+    {
+      "path": "LICENSE",
+      "addressable": true
+    }
+  ],
+  "content": {
+    "details": {
+      "path": "marketplace.md"
+    },
+    "license": {
+      "path": "LICENSE"
+    }
+  },
+  "links": {
+    "home": {
+      "uri": "https://snyk.io/"
+    },
+    "support": {
+      "uri": "https://support.snyk.io/"
+    },
+    "privacypolicy": {
+      "uri": "https://snyk.io/policies/privacy/"
+    },
+    "license": {
+      "uri": "./LICENSE"
+    }
+  },
+  "contributions": [
+    {
+      "id": "custom-build-release-task",
+      "type": "ms.vss-distributed-task.task",
+      "targets": ["ms.vss-distributed-task.tasks"],
+      "properties": {
+        "name": "snykTask"
+      }
+    },
+    {
+      "id": "snyk-report-tab",
+      "type": "ms.vss-build-web.build-results-tab",
+      "description": "Snyk Report",
+      "targets": ["ms.vss-build-web.build-results-view"],
+      "properties": {
+        "name": "Snyk Report",
+        "uri": "ui/snyk-report-tab.html"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Pull Request: Add Preview Deployment Workflow

This pull request introduces a new workflow and configuration updates to support preview deployments for Snyk's Azure DevOps extension.

### Key Changes
 
1. **New deploy_preview Job:**

- Added a *deploy_preview* job in the `.circleci/config.yml` file.
- Configured the preview deployment environment with:
```
AZ_EXTENSION_ID: preview-snyk-security-scan
AZ_EXTENSION_NAME: (Preview) Snyk Security Scan
AZ_PUBLISHER: Snyk
```
- Generated a version string dynamically using the current date and time in the format YYYY.M.DHHMM. The first attempt was around introducing pseudo-versioning but because of the task [limitations](https://github.com/microsoft/azure-pipelines-task-lib/blob/b5a00101f0dc52c7b6716a7bc68720c547065c93/tasks.schema.json#L133-L153) we decided to use date based versioning.
- Introduced the `ci-deploy-preview.sh` script to deploy the extension as Preview.

2. **Approval Step for Preview Deployment:**

- Added an approval step to the workflow to ensure manual confirmation before deploying to the preview environment.
- The Preview deployment can be triggered only from non-main branches.

