### PR TITLE
chore: change serviceConnectionEndpoint datatype to string

### DIFF
--- a/vss-extension-dev.json
+++ b/vss-extension-dev.json
@@ -105,7 +105,7 @@
                 "isConfidential": true,
                 "validation": {
                   "isRequired": true,
-                  "dataType": "guid"
+                  "dataType": "string"
                 }
               }
             ]

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -105,7 +105,7 @@
                 "isConfidential": true,
                 "validation": {
                   "isRequired": true,
-                  "dataType": "guid"
+                  "dataType": "string"
                 }
               }
             ]


### PR DESCRIPTION
Currently, the token type in the serviceConnectionEndpoint value (used as the integration's Snyk token) is set to `GUID`, meaning that it will fail validation when set to a PAT.

This PR changes the type to string to support both PAT and legacy tokens 