### PR TITLE
fix: adjust binary permissions

### DIFF
--- a/snykTask/src/install/index.ts
+++ b/snykTask/src/install/index.ts
@@ -110,7 +110,7 @@ async function download(
 
 function setExecutablePermissions(filePath: string) {
   if (os.platform() !== 'win32') {
-    fs.chmodSync(filePath, 0o111);
+    fs.chmodSync(filePath, 0o755);
     console.log(`Set executable permissions for ${filePath}`);
   }
 }


### PR DESCRIPTION
Some clients of this Azure DevOps Task are reporting issues while executing the binary downloaded from Snyk. The problem was traced to incorrect file permissions being set on Unix-like systems (Linux, macOS).

In `snykTask/src/install/index.ts`, the `setExecutablePermissions` function was setting permissions to `0o111`. 

This PR is changing the permissions from `0o111` to `0o755` to fix the read, access, and write permissions required by the binaries downloaded within the task.