### PR TITLE
feat: support snyk-to-html for sbom test

### DIFF
--- a/ui/enhancer/generate-report-title.ts
+++ b/ui/enhancer/generate-report-title.ts
@@ -47,14 +47,17 @@ export function generateReportTitle(
   }
 
   // Single project scan or Snyk code scan results
-  let titleText = '';
+  let titleText = `Snyk Report (${formatReportName(attachmentName)})`;
   if (jsonResults['docker'] && jsonResults['docker']['baseImage']) {
     titleText = `Snyk Test for ${
       jsonResults['docker']['baseImage']
     } (${formatReportName(attachmentName)})`;
   }
 
-  if (jsonResults['packageManager']) {
+  if (
+    jsonResults['packageManager'] &&
+    jsonResults['packageManager'].length > 0
+  ) {
     titleText = `Snyk Test for ${
       jsonResults['packageManager']
     } (${formatReportName(attachmentName)})`;


### PR DESCRIPTION
This PR adds support for `snyk-to-html` report generation for the `sbom test` command.

When running the command `sbom test` we will now generate a `snyk-to-html` report accessible via the `Snyk Report` tab:

<img width="2321" height="1055" alt="Screenshot 2025-11-07 at 07 41 39" src="https://github.com/user-attachments/assets/5953f583-77c5-4dd0-bb32-3580d9e2b0d4" />
