### PR TITLE
feat: Include environment details in instrumentation data

### DIFF
--- a/snykTask/src/__tests__/task-lib.test.ts
+++ b/snykTask/src/__tests__/task-lib.test.ts
@@ -309,65 +309,71 @@ test('getOptionsToExecuteSnykCLICommand builds IExecOptions like we need it', ()
 });
 
 describe('getAgentEnvironment', () => {
-  it('returns agent name and version from Azure Pipelines variables', () => {
+  it('returns MsHosted and agent version for hosted agents', () => {
+    const getAgentModeSpy = jest
+      .spyOn(tl, 'getAgentMode')
+      .mockReturnValue(tl.AgentHostedMode.MsHosted);
     const getVariableSpy = jest
       .spyOn(tl, 'getVariable')
       .mockImplementation((name: string) => {
-        const vars: Record<string, string> = {
-          'Agent.Name': 'Azure Pipelines 1',
-          'Agent.Version': '4.269.0',
-        };
-        return vars[name];
+        if (name === 'Agent.Version') return '4.269.0';
+        return undefined;
       });
 
     const env = getAgentEnvironment();
-    expect(env.name).toBe('Azure Pipelines 1');
+    expect(env.name).toBe('MsHosted');
     expect(env.version).toBe('4.269.0');
 
+    getAgentModeSpy.mockRestore();
     getVariableSpy.mockRestore();
   });
 
-  it('returns self-hosted agent name and version', () => {
+  it('returns SelfHosted and agent version for self-hosted agents', () => {
+    const getAgentModeSpy = jest
+      .spyOn(tl, 'getAgentMode')
+      .mockReturnValue(tl.AgentHostedMode.SelfHosted);
     const getVariableSpy = jest
       .spyOn(tl, 'getVariable')
       .mockImplementation((name: string) => {
-        const vars: Record<string, string> = {
-          'Agent.Name': 'my-custom-agent',
-          'Agent.Version': '3.227.0',
-        };
-        return vars[name];
+        if (name === 'Agent.Version') return '3.227.0';
+        return undefined;
       });
 
     const env = getAgentEnvironment();
-    expect(env.name).toBe('my-custom-agent');
+    expect(env.name).toBe('SelfHosted');
     expect(env.version).toBe('3.227.0');
 
+    getAgentModeSpy.mockRestore();
     getVariableSpy.mockRestore();
   });
 
-  it('handles missing agent variables gracefully', () => {
+  it('returns Unknown when agent mode cannot be determined', () => {
+    const getAgentModeSpy = jest
+      .spyOn(tl, 'getAgentMode')
+      .mockReturnValue(tl.AgentHostedMode.Unknown);
     const getVariableSpy = jest
       .spyOn(tl, 'getVariable')
       .mockReturnValue(undefined);
 
     const env = getAgentEnvironment();
-    expect(env.name).toBe('');
+    expect(env.name).toBe('Unknown');
     expect(env.version).toBe('');
 
+    getAgentModeSpy.mockRestore();
     getVariableSpy.mockRestore();
   });
 });
 
 describe('getOptionsToExecuteSnykCLICommand environment variables', () => {
   it('includes SNYK_INTEGRATION_ENVIRONMENT and SNYK_INTEGRATION_ENVIRONMENT_VERSION', () => {
+    const getAgentModeSpy = jest
+      .spyOn(tl, 'getAgentMode')
+      .mockReturnValue(tl.AgentHostedMode.MsHosted);
     const getVariableSpy = jest
       .spyOn(tl, 'getVariable')
       .mockImplementation((name: string) => {
-        const vars: Record<string, string> = {
-          'Agent.Name': 'Azure Pipelines 1',
-          'Agent.Version': '4.269.0',
-        };
-        return vars[name];
+        if (name === 'Agent.Version') return '4.269.0';
+        return undefined;
       });
 
     const taskArgs: TaskArgs = new TaskArgs({ failOnIssues: true });
@@ -380,9 +386,10 @@ describe('getOptionsToExecuteSnykCLICommand environment variables', () => {
       'fake-token',
     );
 
-    expect(options.env?.SNYK_INTEGRATION_ENVIRONMENT).toBe('Azure Pipelines 1');
+    expect(options.env?.SNYK_INTEGRATION_ENVIRONMENT).toBe('MsHosted');
     expect(options.env?.SNYK_INTEGRATION_ENVIRONMENT_VERSION).toBe('4.269.0');
 
+    getAgentModeSpy.mockRestore();
     getVariableSpy.mockRestore();
   });
 });

--- a/snykTask/src/__tests__/task-lib.test.ts
+++ b/snykTask/src/__tests__/task-lib.test.ts
@@ -43,6 +43,18 @@ import { execSync } from 'child_process';
 let tempFolder = '';
 let snykCliPath = '';
 
+/** Stubs `tl.getAgentMode` and `tl.getVariable` for agent instrumentation tests. Mocks are restored by `afterEach`. */
+function stubAzureAgentContext(
+  mode: tl.AgentHostedMode,
+  agentVersion: string | undefined,
+): void {
+  jest.spyOn(tl, 'getAgentMode').mockReturnValue(mode);
+  jest.spyOn(tl, 'getVariable').mockImplementation((name: string) => {
+    if (name === 'Agent.Version') return agentVersion;
+    return undefined;
+  });
+}
+
 function getTestToken(): string {
   if (process.env.SNYK_TOKEN === undefined) {
     const output = execSync(snykCliPath + ' config get api');
@@ -310,71 +322,33 @@ test('getOptionsToExecuteSnykCLICommand builds IExecOptions like we need it', ()
 
 describe('getAgentEnvironment', () => {
   it('returns MsHosted and agent version for hosted agents', () => {
-    const getAgentModeSpy = jest
-      .spyOn(tl, 'getAgentMode')
-      .mockReturnValue(tl.AgentHostedMode.MsHosted);
-    const getVariableSpy = jest
-      .spyOn(tl, 'getVariable')
-      .mockImplementation((name: string) => {
-        if (name === 'Agent.Version') return '4.269.0';
-        return undefined;
-      });
+    stubAzureAgentContext(tl.AgentHostedMode.MsHosted, '4.269.0');
 
     const env = getAgentEnvironment();
     expect(env.name).toBe('MsHosted');
     expect(env.version).toBe('4.269.0');
-
-    getAgentModeSpy.mockRestore();
-    getVariableSpy.mockRestore();
   });
 
   it('returns SelfHosted and agent version for self-hosted agents', () => {
-    const getAgentModeSpy = jest
-      .spyOn(tl, 'getAgentMode')
-      .mockReturnValue(tl.AgentHostedMode.SelfHosted);
-    const getVariableSpy = jest
-      .spyOn(tl, 'getVariable')
-      .mockImplementation((name: string) => {
-        if (name === 'Agent.Version') return '3.227.0';
-        return undefined;
-      });
+    stubAzureAgentContext(tl.AgentHostedMode.SelfHosted, '3.227.0');
 
     const env = getAgentEnvironment();
     expect(env.name).toBe('SelfHosted');
     expect(env.version).toBe('3.227.0');
-
-    getAgentModeSpy.mockRestore();
-    getVariableSpy.mockRestore();
   });
 
   it('returns Unknown when agent mode cannot be determined', () => {
-    const getAgentModeSpy = jest
-      .spyOn(tl, 'getAgentMode')
-      .mockReturnValue(tl.AgentHostedMode.Unknown);
-    const getVariableSpy = jest
-      .spyOn(tl, 'getVariable')
-      .mockReturnValue(undefined);
+    stubAzureAgentContext(tl.AgentHostedMode.Unknown, undefined);
 
     const env = getAgentEnvironment();
     expect(env.name).toBe('Unknown');
     expect(env.version).toBe('');
-
-    getAgentModeSpy.mockRestore();
-    getVariableSpy.mockRestore();
   });
 });
 
 describe('getOptionsToExecuteSnykCLICommand environment variables', () => {
   it('includes SNYK_INTEGRATION_ENVIRONMENT and SNYK_INTEGRATION_ENVIRONMENT_VERSION', () => {
-    const getAgentModeSpy = jest
-      .spyOn(tl, 'getAgentMode')
-      .mockReturnValue(tl.AgentHostedMode.MsHosted);
-    const getVariableSpy = jest
-      .spyOn(tl, 'getVariable')
-      .mockImplementation((name: string) => {
-        if (name === 'Agent.Version') return '4.269.0';
-        return undefined;
-      });
+    stubAzureAgentContext(tl.AgentHostedMode.MsHosted, '4.269.0');
 
     const taskArgs: TaskArgs = new TaskArgs({ failOnIssues: true });
     taskArgs.testDirectory = '/some/path';
@@ -388,9 +362,6 @@ describe('getOptionsToExecuteSnykCLICommand environment variables', () => {
 
     expect(options.env?.SNYK_INTEGRATION_ENVIRONMENT).toBe('MsHosted');
     expect(options.env?.SNYK_INTEGRATION_ENVIRONMENT_VERSION).toBe('4.269.0');
-
-    getAgentModeSpy.mockRestore();
-    getVariableSpy.mockRestore();
   });
 });
 

--- a/snykTask/src/__tests__/task-lib.test.ts
+++ b/snykTask/src/__tests__/task-lib.test.ts
@@ -30,6 +30,7 @@ import {
   getOptionsToExecuteSnykCLICommand,
   getOptionsToExecuteCmd,
   getOptionsForSnykToHtml,
+  getAgentEnvironment,
   formatDate,
   attachReport,
   removeRegexFromFile,
@@ -305,6 +306,113 @@ test('getOptionsToExecuteSnykCLICommand builds IExecOptions like we need it', ()
   expect(options.env?.SNYK_INTEGRATION_NAME).toBe('AZURE_PIPELINES');
   expect(options.env?.SNYK_INTEGRATION_VERSION).toBe(version);
   expect(options.env?.SNYK_TOKEN).toBe('fake-token');
+});
+
+describe('getAgentEnvironment', () => {
+  it('returns hosted agent details when agent name starts with Azure Pipelines', () => {
+    const getVariableSpy = jest
+      .spyOn(tl, 'getVariable')
+      .mockImplementation((name: string) => {
+        const vars: Record<string, string> = {
+          'Agent.Name': 'Azure Pipelines 1',
+          'Agent.Version': '4.269.0',
+          ImageVersion: '20260302.42.1',
+          'Agent.OS': 'Linux',
+        };
+        return vars[name];
+      });
+
+    const env = getAgentEnvironment();
+    expect(env.name).toBe('Hosted_Compute_Agent-4.269.0');
+    expect(env.version).toBe('20260302.42.1');
+
+    getVariableSpy.mockRestore();
+  });
+
+  it('returns self-hosted agent details when agent name does not start with Azure Pipelines', () => {
+    const getVariableSpy = jest
+      .spyOn(tl, 'getVariable')
+      .mockImplementation((name: string) => {
+        const vars: Record<string, string> = {
+          'Agent.Name': 'my-custom-agent',
+          'Agent.Version': '3.227.0',
+          'Agent.OS': 'Windows_NT',
+        };
+        return vars[name];
+      });
+
+    const env = getAgentEnvironment();
+    expect(env.name).toBe('Self_Hosted_Agent-3.227.0');
+    expect(env.version).toBe('Windows_NT');
+
+    getVariableSpy.mockRestore();
+  });
+
+  it('falls back to Agent.OS when ImageVersion is not available', () => {
+    const getVariableSpy = jest
+      .spyOn(tl, 'getVariable')
+      .mockImplementation((name: string) => {
+        const vars: Record<string, string> = {
+          'Agent.Name': 'Azure Pipelines 1',
+          'Agent.Version': '4.269.0',
+          'Agent.OS': 'Darwin',
+        };
+        return vars[name];
+      });
+
+    const env = getAgentEnvironment();
+    expect(env.name).toBe('Hosted_Compute_Agent-4.269.0');
+    expect(env.version).toBe('Darwin');
+
+    getVariableSpy.mockRestore();
+  });
+
+  it('handles missing agent variables gracefully', () => {
+    const getVariableSpy = jest
+      .spyOn(tl, 'getVariable')
+      .mockReturnValue(undefined);
+
+    const env = getAgentEnvironment();
+    expect(env.name).toBe('Self_Hosted_Agent-');
+    expect(env.version).toBe('');
+
+    getVariableSpy.mockRestore();
+  });
+});
+
+describe('getOptionsToExecuteSnykCLICommand environment variables', () => {
+  it('includes SNYK_INTEGRATION_ENVIRONMENT and SNYK_INTEGRATION_ENVIRONMENT_VERSION', () => {
+    const getVariableSpy = jest
+      .spyOn(tl, 'getVariable')
+      .mockImplementation((name: string) => {
+        const vars: Record<string, string> = {
+          'Agent.Name': 'Azure Pipelines 1',
+          'Agent.Version': '4.269.0',
+          ImageVersion: '20260302.42.1',
+          'Agent.OS': 'Linux',
+        };
+        return vars[name];
+      });
+
+    const taskArgs: TaskArgs = new TaskArgs({ failOnIssues: true });
+    taskArgs.testDirectory = '/some/path';
+
+    const options = getOptionsToExecuteSnykCLICommand(
+      taskArgs,
+      'AZURE_PIPELINES',
+      '1.2.3',
+      'fake-token',
+    );
+
+    expect(options.env?.SNYK_INTEGRATION_ENVIRONMENT).toBe(
+      'Hosted_Compute_Agent-4.269.0',
+    );
+    expect(options.env?.SNYK_INTEGRATION_ENVIRONMENT_VERSION).toBe(
+      '20260302.42.1',
+    );
+
+    getVariableSpy.mockRestore();
+  });
 });
 
 describe('getOptionsForSnykToHtml', () => {

--- a/snykTask/src/__tests__/task-lib.test.ts
+++ b/snykTask/src/__tests__/task-lib.test.ts
@@ -309,60 +309,38 @@ test('getOptionsToExecuteSnykCLICommand builds IExecOptions like we need it', ()
 });
 
 describe('getAgentEnvironment', () => {
-  it('returns hosted agent details when agent name starts with Azure Pipelines', () => {
+  it('returns agent name and version from Azure Pipelines variables', () => {
     const getVariableSpy = jest
       .spyOn(tl, 'getVariable')
       .mockImplementation((name: string) => {
         const vars: Record<string, string> = {
           'Agent.Name': 'Azure Pipelines 1',
           'Agent.Version': '4.269.0',
-          ImageVersion: '20260302.42.1',
-          'Agent.OS': 'Linux',
         };
         return vars[name];
       });
 
     const env = getAgentEnvironment();
-    expect(env.name).toBe('Hosted_Compute_Agent-4.269.0');
-    expect(env.version).toBe('20260302.42.1');
+    expect(env.name).toBe('Azure Pipelines 1');
+    expect(env.version).toBe('4.269.0');
 
     getVariableSpy.mockRestore();
   });
 
-  it('returns self-hosted agent details when agent name does not start with Azure Pipelines', () => {
+  it('returns self-hosted agent name and version', () => {
     const getVariableSpy = jest
       .spyOn(tl, 'getVariable')
       .mockImplementation((name: string) => {
         const vars: Record<string, string> = {
           'Agent.Name': 'my-custom-agent',
           'Agent.Version': '3.227.0',
-          'Agent.OS': 'Windows_NT',
         };
         return vars[name];
       });
 
     const env = getAgentEnvironment();
-    expect(env.name).toBe('Self_Hosted_Agent-3.227.0');
-    expect(env.version).toBe('Windows_NT');
-
-    getVariableSpy.mockRestore();
-  });
-
-  it('falls back to Agent.OS when ImageVersion is not available', () => {
-    const getVariableSpy = jest
-      .spyOn(tl, 'getVariable')
-      .mockImplementation((name: string) => {
-        const vars: Record<string, string> = {
-          'Agent.Name': 'Azure Pipelines 1',
-          'Agent.Version': '4.269.0',
-          'Agent.OS': 'Darwin',
-        };
-        return vars[name];
-      });
-
-    const env = getAgentEnvironment();
-    expect(env.name).toBe('Hosted_Compute_Agent-4.269.0');
-    expect(env.version).toBe('Darwin');
+    expect(env.name).toBe('my-custom-agent');
+    expect(env.version).toBe('3.227.0');
 
     getVariableSpy.mockRestore();
   });
@@ -373,7 +351,7 @@ describe('getAgentEnvironment', () => {
       .mockReturnValue(undefined);
 
     const env = getAgentEnvironment();
-    expect(env.name).toBe('Self_Hosted_Agent-');
+    expect(env.name).toBe('');
     expect(env.version).toBe('');
 
     getVariableSpy.mockRestore();
@@ -388,8 +366,6 @@ describe('getOptionsToExecuteSnykCLICommand environment variables', () => {
         const vars: Record<string, string> = {
           'Agent.Name': 'Azure Pipelines 1',
           'Agent.Version': '4.269.0',
-          ImageVersion: '20260302.42.1',
-          'Agent.OS': 'Linux',
         };
         return vars[name];
       });
@@ -404,12 +380,8 @@ describe('getOptionsToExecuteSnykCLICommand environment variables', () => {
       'fake-token',
     );
 
-    expect(options.env?.SNYK_INTEGRATION_ENVIRONMENT).toBe(
-      'Hosted_Compute_Agent-4.269.0',
-    );
-    expect(options.env?.SNYK_INTEGRATION_ENVIRONMENT_VERSION).toBe(
-      '20260302.42.1',
-    );
+    expect(options.env?.SNYK_INTEGRATION_ENVIRONMENT).toBe('Azure Pipelines 1');
+    expect(options.env?.SNYK_INTEGRATION_ENVIRONMENT_VERSION).toBe('4.269.0');
 
     getVariableSpy.mockRestore();
   });

--- a/snykTask/src/task-lib.ts
+++ b/snykTask/src/task-lib.ts
@@ -32,12 +32,26 @@ export const getOptionsToExecuteCmd = (taskArgs: TaskArgs): tr.IExecOptions => {
   } as tr.IExecOptions;
 };
 
+export function getAgentEnvironment(): {
+  name: string;
+  version: string;
+} {
+  const agentName = tl.getVariable('Agent.Name') || '';
+  const agentVersion = tl.getVariable('Agent.Version') || '';
+  const isHosted = agentName.startsWith('Azure Pipelines');
+  const name = `${isHosted ? 'Hosted_Compute_Agent' : 'Self_Hosted_Agent'}-${agentVersion}`;
+  const version =
+    tl.getVariable('ImageVersion') || tl.getVariable('Agent.OS') || '';
+  return { name, version };
+}
+
 export const getOptionsToExecuteSnykCLICommand = (
   taskArgs: TaskArgs,
   taskNameForAnalytics: string,
   taskVersion: string,
   snykToken: string,
 ): tr.IExecOptions => {
+  const agentEnv = getAgentEnvironment();
   const options = {
     cwd: taskArgs.testDirectory,
     failOnStdErr: false,
@@ -46,6 +60,8 @@ export const getOptionsToExecuteSnykCLICommand = (
       ...process.env,
       SNYK_INTEGRATION_NAME: taskNameForAnalytics,
       SNYK_INTEGRATION_VERSION: taskVersion,
+      SNYK_INTEGRATION_ENVIRONMENT: agentEnv.name,
+      SNYK_INTEGRATION_ENVIRONMENT_VERSION: agentEnv.version,
       SNYK_TOKEN: snykToken,
     } as tr.IExecOptions['env'],
   } as tr.IExecOptions;

--- a/snykTask/src/task-lib.ts
+++ b/snykTask/src/task-lib.ts
@@ -39,7 +39,9 @@ export function getAgentEnvironment(): {
   const agentName = tl.getVariable('Agent.Name') || '';
   const agentVersion = tl.getVariable('Agent.Version') || '';
   const isHosted = agentName.startsWith('Azure Pipelines');
-  const name = `${isHosted ? 'Hosted_Compute_Agent' : 'Self_Hosted_Agent'}-${agentVersion}`;
+  const name = `${
+    isHosted ? 'Hosted_Compute_Agent' : 'Self_Hosted_Agent'
+  }-${agentVersion}`;
   const version =
     tl.getVariable('ImageVersion') || tl.getVariable('Agent.OS') || '';
   return { name, version };

--- a/snykTask/src/task-lib.ts
+++ b/snykTask/src/task-lib.ts
@@ -36,7 +36,7 @@ export function getAgentEnvironment(): {
   name: string;
   version: string;
 } {
-  const name = tl.getVariable('Agent.Name') || '';
+  const name = tl.AgentHostedMode[tl.getAgentMode()];
   const version = tl.getVariable('Agent.Version') || '';
   return { name, version };
 }

--- a/snykTask/src/task-lib.ts
+++ b/snykTask/src/task-lib.ts
@@ -36,14 +36,8 @@ export function getAgentEnvironment(): {
   name: string;
   version: string;
 } {
-  const agentName = tl.getVariable('Agent.Name') || '';
-  const agentVersion = tl.getVariable('Agent.Version') || '';
-  const isHosted = agentName.startsWith('Azure Pipelines');
-  const name = `${
-    isHosted ? 'Hosted_Compute_Agent' : 'Self_Hosted_Agent'
-  }-${agentVersion}`;
-  const version =
-    tl.getVariable('ImageVersion') || tl.getVariable('Agent.OS') || '';
+  const name = tl.getVariable('Agent.Name') || '';
+  const version = tl.getVariable('Agent.Version') || '';
   return { name, version };
 }
 


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are release-note ready
- [x] Includes detailed description of changes
- [x] Contains risk assessment
- [x] Links to automated tests covering new functionality

## What does this PR do?

Adds `SNYK_INTEGRATION_ENVIRONMENT` and `SNYK_INTEGRATION_ENVIRONMENT_VERSION` to the env passed into the Snyk CLI so instrumentation can include an optional `environment` block describing the Azure Pipelines agent.

- **`SNYK_INTEGRATION_ENVIRONMENT`** — Hosted vs self-hosted vs unknown, using **`tl.getAgentMode()`** and the **`AgentHostedMode`** enum string from `azure-pipelines-task-lib`: `MsHosted`, `SelfHosted`, or `Unknown` (derived from `Agent.CloudId` in the agent runtime).
- **`SNYK_INTEGRATION_ENVIRONMENT_VERSION`** — **`Agent.Version`** (e.g. `4.269.0`). If unset, **`''`**.

OS / image details stay in the existing **`platform`** slice of instrumentation; they are not duplicated here.

Example shape:

```json
{
  "environment": {
    "name": "MsHosted",
    "version": "4.269.0"
  }
}
```

## Where should the reviewer start?
snykTask/src/task-lib.ts — getAgentEnvironment() and getOptionsToExecuteSnykCLICommand (including optional apiUrl → SNYK_API).
snykTask/src/__tests__/task-lib.test.ts — stubAzureAgentContext helper; tests for MsHosted / SelfHosted / Unknown and env wiring.

## Risk assessment
Low. Additive env vars for the CLI process; no change to task inputs or user-facing behavior. getAgentMode / Agent.Version are standard Azure Pipelines agent surface area via azure-pipelines-task-lib.

## What are the relevant tickets?
[CLI-1396](https://snyksec.atlassian.net/browse/CLI-1396)

[CLI-1396]: https://snyksec.atlassian.net/browse/CLI-1396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ