### PR TITLE
chore: E2E test coverage for Snyk Azure Pipelines task entry point

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,10 @@ jobs:
           name: Unit Tests
           command: |
             npm run test:unit
+      - run:
+          name: Integration Tests (Snyk task E2E)
+          command: |
+            npm run test:integration
 
   deploy_dev:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,7 +194,10 @@ workflows:
       - security-scans:
           context: devex_cli
 
-      - test
+      - test:
+          context:
+            - team_hammerhead-cli
+
       - deploy_dev:
           requires:
             - test

--- a/jest.config.js
+++ b/jest.config.js
@@ -23,5 +23,6 @@ module.exports = {
     '/node_modules/',
     'snykTask/src/__tests__/_test-mock-config-*',
     'snykTask/src/__tests__/test-task.ts',
+    'snykTask/src/__tests__/__integration__',
   ],
 };

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:checks": "npm run eslint && npm run format:check",
     "test:snyk": "npx snyk test --severity-threshold=high",
     "test:unit": "jest",
-    "test:integration": "npm run compile && jest --testPathPattern='__integration__' --testPathIgnorePatterns='/node_modules/' --no-coverage --testTimeout=120000",
+    "test:integration": "npm run compile && jest --testPathPattern='\\.integration\\.test\\.ts$' --testPathIgnorePatterns='/node_modules/' --no-coverage --testTimeout=120000",
     "compile": "tsc -b snykTask/tsconfig.json",
     "eslint": "eslint --cache 'snykTask/{src,test,public/js/{!(build)}}/**/*.{js,ts}'",
     "format:check": "prettier --check '**/*.{js,ts,json,yaml,yml,md,html}'",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:checks": "npm run eslint && npm run format:check",
     "test:snyk": "npx snyk test --severity-threshold=high",
     "test:unit": "jest",
+    "test:integration": "npm run compile && jest --testPathPattern='__integration__' --testPathIgnorePatterns='/node_modules/' --no-coverage --testTimeout=120000",
     "compile": "tsc -b snykTask/tsconfig.json",
     "eslint": "eslint --cache 'snykTask/{src,test,public/js/{!(build)}}/**/*.{js,ts}'",
     "format:check": "prettier --check '**/*.{js,ts,json,yaml,yml,md,html}'",

--- a/snykTask/package-lock.json
+++ b/snykTask/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "azure-pipelines-task-lib": "4.7.0",
+        "azure-pipelines-task-lib": "4.17.3",
         "azure-pipelines-tool-lib": "2.0.8"
       }
     },
@@ -39,16 +39,16 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.7.0.tgz",
-      "integrity": "sha512-5MctDC1Bt7eFi9tQTXlikuWRDc2MenCNruMsEwcKuXqBj1ZY+fA/D+E1DbE0Qi2u8kl1p6szT0we8k6RHSOe/w==",
+      "version": "4.17.3",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.17.3.tgz",
+      "integrity": "sha512-UxfH5pk3uOHTi9TtLtdDyugQVkFES5A836ZEePjcs3jYyxm3EJ6IlFYq6gbfd6mNBhrM9fxG2u/MFYIJ+Z0cxQ==",
+      "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",
-        "deasync": "^0.1.28",
         "minimatch": "3.0.5",
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
-        "semver": "^5.1.0",
+        "semver": "^5.7.2",
         "shelljs": "^0.8.5",
         "uuid": "^3.0.1"
       }
@@ -71,14 +71,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -120,19 +112,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
-    },
-    "node_modules/deasync": {
-      "version": "0.1.30",
-      "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.30.tgz",
-      "integrity": "sha512-OaAjvEQuQ9tJsKG4oHO9nV1UHTwb2Qc2+fadB0VeVtD0Z9wiG1XPGLJ4W3aLhAoQSYTaLROFRbd5X20Dkzf7MQ==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "node-addon-api": "^1.7.1"
-      },
-      "engines": {
-        "node": ">=0.11.0"
-      }
     },
     "node_modules/debug": {
       "version": "4.3.5",
@@ -189,11 +168,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "node_modules/follow-redirects": {
       "version": "1.15.6",
@@ -412,11 +386,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "node_modules/node-addon-api": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
-      "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg=="
     },
     "node_modules/nodejs-file-downloader": {
       "version": "4.13.0",
@@ -703,16 +672,15 @@
       }
     },
     "azure-pipelines-task-lib": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.7.0.tgz",
-      "integrity": "sha512-5MctDC1Bt7eFi9tQTXlikuWRDc2MenCNruMsEwcKuXqBj1ZY+fA/D+E1DbE0Qi2u8kl1p6szT0we8k6RHSOe/w==",
+      "version": "4.17.3",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.17.3.tgz",
+      "integrity": "sha512-UxfH5pk3uOHTi9TtLtdDyugQVkFES5A836ZEePjcs3jYyxm3EJ6IlFYq6gbfd6mNBhrM9fxG2u/MFYIJ+Z0cxQ==",
       "requires": {
         "adm-zip": "^0.5.10",
-        "deasync": "^0.1.28",
         "minimatch": "3.1.5",
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
-        "semver": "^5.1.0",
+        "semver": "^5.7.2",
         "shelljs": "^0.8.5",
         "uuid": "^3.0.1"
       }
@@ -735,14 +703,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-    },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -775,15 +735,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
-    },
-    "deasync": {
-      "version": "0.1.30",
-      "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.30.tgz",
-      "integrity": "sha512-OaAjvEQuQ9tJsKG4oHO9nV1UHTwb2Qc2+fadB0VeVtD0Z9wiG1XPGLJ4W3aLhAoQSYTaLROFRbd5X20Dkzf7MQ==",
-      "requires": {
-        "bindings": "^1.5.0",
-        "node-addon-api": "^1.7.1"
-      }
     },
     "debug": {
       "version": "4.3.5",
@@ -820,11 +771,6 @@
       "requires": {
         "es-errors": "^1.3.0"
       }
-    },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "follow-redirects": {
       "version": "1.15.6",
@@ -972,11 +918,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "node-addon-api": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
-      "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg=="
     },
     "nodejs-file-downloader": {
       "version": "4.13.0",

--- a/snykTask/package.json
+++ b/snykTask/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "azure-pipelines-task-lib": "4.7.0",
+    "azure-pipelines-task-lib": "4.17.3",
     "azure-pipelines-tool-lib": "2.0.8"
   },
   "overrides": {

--- a/snykTask/src/__tests__/.env.example
+++ b/snykTask/src/__tests__/.env.example
@@ -1,0 +1,7 @@
+# Copy to `snykTask/src/__tests__/.env` (gitignored) or set in your environment.
+# Required for `npm run test:integration`.
+
+SNYK_TOKEN=
+
+# Optional: copy integration artifacts here when not using INTEGRATION_ARTIFACTS_OUTPUT_DIR in the test file.
+# SNYK_INTEGRATION_ARTIFACTS_DIR=

--- a/snykTask/src/__tests__/.env.example
+++ b/snykTask/src/__tests__/.env.example
@@ -1,7 +1,0 @@
-# Copy to `snykTask/src/__tests__/.env` (gitignored) or set in your environment.
-# Required for `npm run test:integration`.
-
-SNYK_TOKEN=
-
-# Optional: copy integration artifacts here when not using INTEGRATION_ARTIFACTS_OUTPUT_DIR in the test file.
-# SNYK_INTEGRATION_ARTIFACTS_DIR=

--- a/snykTask/src/__tests__/__integration__/index.integration.test.ts
+++ b/snykTask/src/__tests__/__integration__/index.integration.test.ts
@@ -93,8 +93,7 @@ describe('Snyk Task E2E', () => {
         path.join(tempDir, jsonReport as string),
         'utf8',
       );
-      const parsed = JSON.parse(content) as Record<string, unknown>;
-      assertSnykTestJsonReport(parsed, projectRoot);
+      assertSnykTestJsonReport(content);
 
       const htmlReport = (jsonReport as string).replace(/\.json$/i, '.html');
       expect(fs.existsSync(path.join(tempDir, htmlReport))).toBe(true);

--- a/snykTask/src/__tests__/__integration__/index.integration.test.ts
+++ b/snykTask/src/__tests__/__integration__/index.integration.test.ts
@@ -1,0 +1,212 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { TaskMockRunner } from 'azure-pipelines-task-lib/mock-run';
+
+/**
+ * Copy integration artifacts (JSON, HTML, downloaded binaries) after each test.
+ * Takes precedence over `SNYK_INTEGRATION_ARTIFACTS_DIR` when non-empty.
+ *
+ * Relative paths (e.g. `./snyk-integration-artifacts` or `.`) are resolved from
+ * `process.cwd()` — when you run `npm run test:integration` from the repo root,
+ * not this file’s directory. `./` therefore dumps under the
+ * project root (same as `.`).
+ *
+ * For a folder next to this test file, use e.g.
+ * `path.join(__dirname, 'integration-artifacts')`.
+ *
+ * If empty, falls back to the env var (same resolution rules for relative paths).
+ * Must be a string (e.g. from `path.join` or `''`);
+ */
+const INTEGRATION_ARTIFACTS_OUTPUT_DIR = path.join(
+  __dirname,
+  'integration-artifacts',
+);
+
+/** Shape checks for `snyk test` JSON output; values that hold for this repo on any OS. */
+function assertSnykTestJsonReport(
+  parsed: Record<string, unknown>,
+  expectedProjectRoot: string,
+): void {
+  expect(parsed.ok).toBe(true);
+  expect(Array.isArray(parsed.vulnerabilities)).toBe(true);
+
+  expect(typeof parsed.org).toBe('string');
+  expect((parsed.org as string).length).toBeGreaterThan(0);
+
+  expect(parsed.packageManager).toBe('npm');
+
+  const pkgPath = path.join(expectedProjectRoot, 'package.json');
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as { name?: string };
+  expect(typeof pkg.name).toBe('string');
+  expect(parsed.projectName).toBe(pkg.name);
+
+  expect(parsed.displayTargetFile).toBe('package-lock.json');
+
+  expect(typeof parsed.dependencyCount).toBe('number');
+  expect(parsed.dependencyCount as number).toBeGreaterThanOrEqual(0);
+
+  expect(typeof parsed.path).toBe('string');
+  expect(path.normalize(parsed.path as string)).toBe(
+    path.normalize(expectedProjectRoot),
+  );
+
+  expect(typeof parsed.summary).toBe('string');
+  expect((parsed.summary as string).length).toBeGreaterThan(0);
+}
+
+describe('Snyk Task E2E', () => {
+  let tempDir: string;
+  const savedEnv: Record<string, string | undefined> = {};
+  const envKeysToRestore: string[] = [];
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'snyk-integration-'));
+
+    const keysToSave = [
+      'AGENT_TEMPDIRECTORY',
+      ...Object.keys(process.env).filter(
+        (k) =>
+          k.startsWith('INPUT_') ||
+          k.startsWith('ENDPOINT_') ||
+          k.startsWith('SECRET_'),
+      ),
+    ];
+    for (const key of keysToSave) {
+      savedEnv[key] = process.env[key];
+      envKeysToRestore.push(key);
+    }
+
+    process.env['AGENT_TEMPDIRECTORY'] = tempDir;
+  });
+
+  afterEach(() => {
+    for (const key of envKeysToRestore) {
+      if (savedEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = savedEnv[key];
+    }
+    envKeysToRestore.length = 0;
+
+    maybeCopyArtifactsThenRemoveTempDir(tempDir);
+
+    Object.keys(require.cache)
+      .filter(
+        (k) =>
+          k.includes('dist/index') || k.includes('azure-pipelines-task-lib'),
+      )
+      .forEach((k) => delete require.cache[k]);
+  });
+
+  /**
+   * End-to-end: real task lib, CLI download, `snyk test`, JSON report on disk.
+   * Service connection URL → SNYK_API is not echoed in the report; that is covered by unit tests.
+   */
+  it('generates a JSON report file with expected shape', async () => {
+    const snykToken = loadSnykToken();
+    const taskPath = path.join(__dirname, '..', '..', '..', 'dist', 'index.js');
+    const projectRoot = process.cwd();
+
+    const tmr = new TaskMockRunner(taskPath);
+    tmr.setInput('serviceConnectionEndpoint', 'SnykConnection');
+    tmr.setInput('failOnIssues', 'true');
+    tmr.setInput('monitorWhen', 'never');
+
+    process.env['ENDPOINT_URL_SnykConnection'] = 'https://api.eu.snyk.io';
+    process.env['ENDPOINT_AUTH_SnykConnection'] = JSON.stringify({
+      parameters: { apitoken: snykToken },
+      scheme: 'Token',
+    });
+
+    tmr.run(true);
+    const task = require(taskPath);
+    await task.runPromise;
+
+    const files = fs.readdirSync(tempDir);
+    const jsonReport = files.find(
+      (f) => f.startsWith('report-') && f.endsWith('.json'),
+    );
+    expect(jsonReport).toBeDefined();
+    const content = fs.readFileSync(
+      path.join(tempDir, jsonReport as string),
+      'utf8',
+    );
+    const parsed = JSON.parse(content) as Record<string, unknown>;
+    assertSnykTestJsonReport(parsed, projectRoot);
+
+    // TODO: assert HTML report exists (requires snyk-to-html binary compatible with platform)
+    // TODO: assert tl.setResult was called with Succeeded
+  }, 120_000);
+
+  // TODO: test with a custom CLI path via SNYK_CLI_PATH env var
+});
+
+function trimArtifactsPath(value: unknown): string {
+  if (typeof value !== 'string') return '';
+  return value.trim();
+}
+
+function normalizeArtifactsRoot(raw: string): string {
+  const t = raw.trim();
+  if (!t) return '';
+  return path.isAbsolute(t)
+    ? path.normalize(t)
+    : path.resolve(process.cwd(), t);
+}
+
+function resolveIntegrationArtifactsRoot(): string | undefined {
+  const fromFile = trimArtifactsPath(INTEGRATION_ARTIFACTS_OUTPUT_DIR);
+  if (fromFile) {
+    return normalizeArtifactsRoot(fromFile);
+  }
+  const fromEnv = trimArtifactsPath(process.env.SNYK_INTEGRATION_ARTIFACTS_DIR);
+  if (fromEnv) {
+    return normalizeArtifactsRoot(fromEnv);
+  }
+  return undefined;
+}
+
+function ensureArtifactsDirectoryExists(resolvedRoot: string): void {
+  if (fs.existsSync(resolvedRoot)) {
+    const st = fs.statSync(resolvedRoot);
+    if (!st.isDirectory()) {
+      throw new Error(
+        `Integration artifacts path must be a directory, not a file: ${resolvedRoot}`,
+      );
+    }
+    return;
+  }
+  fs.mkdirSync(resolvedRoot, { recursive: true });
+}
+
+function maybeCopyArtifactsThenRemoveTempDir(dir: string): void {
+  if (!dir || !fs.existsSync(dir)) return;
+
+  const copyDestRoot = resolveIntegrationArtifactsRoot();
+  if (copyDestRoot) {
+    ensureArtifactsDirectoryExists(copyDestRoot);
+    const dest = path.join(
+      copyDestRoot,
+      `run-${new Date().toISOString().replace(/[:.]/g, '-')}`,
+    );
+    fs.mkdirSync(dest, { recursive: true });
+    fs.cpSync(dir, dest, { recursive: true });
+    // eslint-disable-next-line no-console
+    console.log(
+      `Integration test: copied artifacts to ${dest} (from INTEGRATION_ARTIFACTS_OUTPUT_DIR or SNYK_INTEGRATION_ARTIFACTS_DIR)`,
+    );
+  }
+
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function loadSnykToken(): string {
+  const envFile = path.join(__dirname, '..', '.env');
+  if (fs.existsSync(envFile)) {
+    const match = fs.readFileSync(envFile, 'utf8').match(/^SNYK_TOKEN=(.+)$/m);
+    if (match) return match[1].trim();
+  }
+  if (process.env.SNYK_TOKEN) return process.env.SNYK_TOKEN;
+  throw new Error(
+    'SNYK_TOKEN not found. Set SNYK_TOKEN env var or create snykTask/src/__tests__/.env with SNYK_TOKEN=<token>',
+  );
+}

--- a/snykTask/src/__tests__/__integration__/index.integration.test.ts
+++ b/snykTask/src/__tests__/__integration__/index.integration.test.ts
@@ -153,7 +153,7 @@ describe('Snyk Task E2E', () => {
     } finally {
       setResultSpy.mockRestore();
     }
-  }, 60_000);
+  }, 120_000);
 });
 
 function trimArtifactsPath(value: unknown): string {

--- a/snykTask/src/__tests__/__integration__/index.integration.test.ts
+++ b/snykTask/src/__tests__/__integration__/index.integration.test.ts
@@ -99,7 +99,7 @@ describe('Snyk Task E2E', () => {
       const htmlReport = (jsonReport as string).replace(/\.json$/i, '.html');
       expect(fs.existsSync(path.join(tempDir, htmlReport))).toBe(true);
       const html = fs.readFileSync(path.join(tempDir, htmlReport), 'utf8');
-      assertSnykTestHtmlReport(html, projectRoot, pkg.name as string);
+      assertSnykTestHtmlReport(html);
 
       expect(setResultSpy).toHaveBeenCalledWith(
         apTask.TaskResult.Succeeded,

--- a/snykTask/src/__tests__/__integration__/index.integration.test.ts
+++ b/snykTask/src/__tests__/__integration__/index.integration.test.ts
@@ -5,25 +5,15 @@ import { TaskMockRunner } from 'azure-pipelines-task-lib/mock-run';
 
 /**
  * Copy integration artifacts (JSON, HTML, downloaded binaries) after each test.
- * Takes precedence over `SNYK_INTEGRATION_ARTIFACTS_DIR` when non-empty.
- *
- * Relative paths (e.g. `./snyk-integration-artifacts` or `.`) are resolved from
- * `process.cwd()` — when you run `npm run test:integration` from the repo root,
- * not this file’s directory. `./` therefore dumps under the
- * project root (same as `.`).
- *
- * For a folder next to this test file, use e.g.
- * `path.join(__dirname, 'integration-artifacts')`.
- *
- * If empty, falls back to the env var (same resolution rules for relative paths).
- * Must be a string (e.g. from `path.join` or `''`);
+ * Use the following code to copy artifacts to a directory next to this test file:
+ * const INTEGRATION_ARTIFACTS_OUTPUT_DIR = path.join(
+ *   __dirname,
+ *   'integration-artifacts',
+ * );
  */
-const INTEGRATION_ARTIFACTS_OUTPUT_DIR = path.join(
-  __dirname,
-  'integration-artifacts',
-);
+const INTEGRATION_ARTIFACTS_OUTPUT_DIR = '';
 
-/** Shape checks for `snyk test` JSON output; values that hold for this repo on any OS. */
+/** Shape checks for `snyk test` JSON output */
 function assertSnykTestJsonReport(
   parsed: Record<string, unknown>,
   expectedProjectRoot: string,
@@ -190,7 +180,6 @@ function maybeCopyArtifactsThenRemoveTempDir(dir: string): void {
     );
     fs.mkdirSync(dest, { recursive: true });
     fs.cpSync(dir, dest, { recursive: true });
-    // eslint-disable-next-line no-console
     console.log(
       `Integration test: copied artifacts to ${dest} (from INTEGRATION_ARTIFACTS_OUTPUT_DIR or SNYK_INTEGRATION_ARTIFACTS_DIR)`,
     );

--- a/snykTask/src/__tests__/__integration__/index.integration.test.ts
+++ b/snykTask/src/__tests__/__integration__/index.integration.test.ts
@@ -111,7 +111,7 @@ describe('Snyk Task E2E', () => {
     tmr.setInput('failOnIssues', 'true');
     tmr.setInput('monitorWhen', 'never');
 
-    process.env['ENDPOINT_URL_SnykConnection'] = 'https://api.eu.snyk.io';
+    process.env['ENDPOINT_URL_SnykConnection'] = 'https://api.snyk.io';
     process.env['ENDPOINT_AUTH_SnykConnection'] = JSON.stringify({
       parameters: { apitoken: snykToken },
       scheme: 'Token',

--- a/snykTask/src/__tests__/__integration__/index.integration.test.ts
+++ b/snykTask/src/__tests__/__integration__/index.integration.test.ts
@@ -2,63 +2,18 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { TaskMockRunner } from 'azure-pipelines-task-lib/mock-run';
+import {
+  assertSnykTestHtmlReport,
+  assertSnykTestJsonReport,
+  COMPILED_TASK_JS,
+  loadSnykToken,
+  maybeCopyArtifactsThenRemoveTempDir,
+  REPO_ROOT_FOR_SNYK_TEST,
+} from './integration-helpers';
 
-/**
- * Copy integration artifacts (JSON, HTML, downloaded binaries) after each test.
- * Use the following code to copy artifacts to a directory next to this test file:
- * const INTEGRATION_ARTIFACTS_OUTPUT_DIR = path.join(
- *   __dirname,
- *   'integration-artifacts',
- * );
- */
-const INTEGRATION_ARTIFACTS_OUTPUT_DIR = '';
-
-function assertSnykTestJsonReport(
-  parsed: Record<string, unknown>,
-  expectedProjectRoot: string,
-): void {
-  expect(parsed.ok).toBe(true);
-  expect(Array.isArray(parsed.vulnerabilities)).toBe(true);
-
-  expect(typeof parsed.org).toBe('string');
-  expect((parsed.org as string).length).toBeGreaterThan(0);
-
-  expect(parsed.packageManager).toBe('npm');
-
-  const pkgPath = path.join(expectedProjectRoot, 'package.json');
-  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as { name?: string };
-  expect(typeof pkg.name).toBe('string');
-  expect(parsed.projectName).toBe(pkg.name);
-
-  expect(parsed.displayTargetFile).toBe('package-lock.json');
-
-  expect(typeof parsed.dependencyCount).toBe('number');
-  expect(parsed.dependencyCount as number).toBeGreaterThanOrEqual(0);
-
-  expect(typeof parsed.path).toBe('string');
-  expect(path.normalize(parsed.path as string)).toBe(
-    path.normalize(expectedProjectRoot),
-  );
-
-  expect(typeof parsed.summary).toBe('string');
-  expect((parsed.summary as string).length).toBeGreaterThan(0);
-}
-
-function assertSnykTestHtmlReport(
-  html: string,
-  expectedProjectRoot: string,
-  expectedProjectName: string,
-): void {
-  expect(html).toMatch(/<!DOCTYPE html>/i);
-  expect(html).toContain('<title>Snyk test report</title>');
-  expect(html).toContain(
-    '<h1 class="project__header__title">Snyk test report</h1>',
-  );
-  expect(html).toContain('Package Manager</th>');
-  expect(html).toContain('<td class="meta-row-value">npm</td>');
-  expect(html).toContain(expectedProjectName);
-  expect(html).toContain(path.normalize(expectedProjectRoot));
-}
+// You can run this integration test locally by setting the TEST_SNYK_TOKEN environment variable.
+// Example when using 1Password:
+// TEST_SNYK_TOKEN="op://<Vault>/API Credentials/credential" op run -- npm run test:integration
 
 describe('Snyk Task E2E', () => {
   let tempDir: string;
@@ -104,8 +59,8 @@ describe('Snyk Task E2E', () => {
 
   it('runs snyk test end-to-end with expected JSON and HTML reports', async () => {
     const snykToken = loadSnykToken();
-    const taskPath = path.join(__dirname, '..', '..', '..', 'dist', 'index.js');
-    const projectRoot = process.cwd();
+    const taskPath = COMPILED_TASK_JS;
+    const projectRoot = REPO_ROOT_FOR_SNYK_TEST;
     const pkg = JSON.parse(
       fs.readFileSync(path.join(projectRoot, 'package.json'), 'utf8'),
     ) as { name?: string };
@@ -155,73 +110,3 @@ describe('Snyk Task E2E', () => {
     }
   }, 120_000);
 });
-
-function trimArtifactsPath(value: unknown): string {
-  if (typeof value !== 'string') return '';
-  return value.trim();
-}
-
-function normalizeArtifactsRoot(raw: string): string {
-  const t = raw.trim();
-  if (!t) return '';
-  return path.isAbsolute(t)
-    ? path.normalize(t)
-    : path.resolve(process.cwd(), t);
-}
-
-function resolveIntegrationArtifactsRoot(): string | undefined {
-  const fromFile = trimArtifactsPath(INTEGRATION_ARTIFACTS_OUTPUT_DIR);
-  if (fromFile) {
-    return normalizeArtifactsRoot(fromFile);
-  }
-  const fromEnv = trimArtifactsPath(process.env.SNYK_INTEGRATION_ARTIFACTS_DIR);
-  if (fromEnv) {
-    return normalizeArtifactsRoot(fromEnv);
-  }
-  return undefined;
-}
-
-function ensureArtifactsDirectoryExists(resolvedRoot: string): void {
-  if (fs.existsSync(resolvedRoot)) {
-    const st = fs.statSync(resolvedRoot);
-    if (!st.isDirectory()) {
-      throw new Error(
-        `Integration artifacts path must be a directory, not a file: ${resolvedRoot}`,
-      );
-    }
-    return;
-  }
-  fs.mkdirSync(resolvedRoot, { recursive: true });
-}
-
-function maybeCopyArtifactsThenRemoveTempDir(dir: string): void {
-  if (!dir || !fs.existsSync(dir)) return;
-
-  const copyDestRoot = resolveIntegrationArtifactsRoot();
-  if (copyDestRoot) {
-    ensureArtifactsDirectoryExists(copyDestRoot);
-    const dest = path.join(
-      copyDestRoot,
-      `run-${new Date().toISOString().replace(/[:.]/g, '-')}`,
-    );
-    fs.mkdirSync(dest, { recursive: true });
-    fs.cpSync(dir, dest, { recursive: true });
-    console.log(
-      `Integration test: copied artifacts to ${dest} (from INTEGRATION_ARTIFACTS_OUTPUT_DIR or SNYK_INTEGRATION_ARTIFACTS_DIR)`,
-    );
-  }
-
-  fs.rmSync(dir, { recursive: true, force: true });
-}
-
-function loadSnykToken(): string {
-  const envFile = path.join(__dirname, '..', '.env');
-  if (fs.existsSync(envFile)) {
-    const match = fs.readFileSync(envFile, 'utf8').match(/^SNYK_TOKEN=(.+)$/m);
-    if (match) return match[1].trim();
-  }
-  if (process.env.SNYK_TOKEN) return process.env.SNYK_TOKEN;
-  throw new Error(
-    'SNYK_TOKEN not found. Set SNYK_TOKEN env var or create snykTask/src/__tests__/.env with SNYK_TOKEN=<token>',
-  );
-}

--- a/snykTask/src/__tests__/__integration__/index.integration.test.ts
+++ b/snykTask/src/__tests__/__integration__/index.integration.test.ts
@@ -13,7 +13,6 @@ import { TaskMockRunner } from 'azure-pipelines-task-lib/mock-run';
  */
 const INTEGRATION_ARTIFACTS_OUTPUT_DIR = '';
 
-/** Shape checks for `snyk test` JSON output */
 function assertSnykTestJsonReport(
   parsed: Record<string, unknown>,
   expectedProjectRoot: string,
@@ -43,6 +42,22 @@ function assertSnykTestJsonReport(
 
   expect(typeof parsed.summary).toBe('string');
   expect((parsed.summary as string).length).toBeGreaterThan(0);
+}
+
+function assertSnykTestHtmlReport(
+  html: string,
+  expectedProjectRoot: string,
+  expectedProjectName: string,
+): void {
+  expect(html).toMatch(/<!DOCTYPE html>/i);
+  expect(html).toContain('<title>Snyk test report</title>');
+  expect(html).toContain(
+    '<h1 class="project__header__title">Snyk test report</h1>',
+  );
+  expect(html).toContain('Package Manager</th>');
+  expect(html).toContain('<td class="meta-row-value">npm</td>');
+  expect(html).toContain(expectedProjectName);
+  expect(html).toContain(path.normalize(expectedProjectRoot));
 }
 
 describe('Snyk Task E2E', () => {
@@ -87,14 +102,14 @@ describe('Snyk Task E2E', () => {
       .forEach((k) => delete require.cache[k]);
   });
 
-  /**
-   * End-to-end: real task lib, CLI download, `snyk test`, JSON report on disk.
-   * Service connection URL → SNYK_API is not echoed in the report; that is covered by unit tests.
-   */
-  it('generates a JSON report file with expected shape', async () => {
+  it('runs snyk test end-to-end with expected JSON and HTML reports', async () => {
     const snykToken = loadSnykToken();
     const taskPath = path.join(__dirname, '..', '..', '..', 'dist', 'index.js');
     const projectRoot = process.cwd();
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(projectRoot, 'package.json'), 'utf8'),
+    ) as { name?: string };
+    expect(typeof pkg.name).toBe('string');
 
     const tmr = new TaskMockRunner(taskPath);
     tmr.setInput('serviceConnectionEndpoint', 'SnykConnection');
@@ -107,27 +122,38 @@ describe('Snyk Task E2E', () => {
       scheme: 'Token',
     });
 
-    tmr.run(true);
-    const task = require(taskPath);
-    await task.runPromise;
+    const apTask = await import('azure-pipelines-task-lib/task');
+    const setResultSpy = jest.spyOn(apTask, 'setResult');
+    try {
+      tmr.run(true);
+      const task = require(taskPath);
+      await task.runPromise;
 
-    const files = fs.readdirSync(tempDir);
-    const jsonReport = files.find(
-      (f) => f.startsWith('report-') && f.endsWith('.json'),
-    );
-    expect(jsonReport).toBeDefined();
-    const content = fs.readFileSync(
-      path.join(tempDir, jsonReport as string),
-      'utf8',
-    );
-    const parsed = JSON.parse(content) as Record<string, unknown>;
-    assertSnykTestJsonReport(parsed, projectRoot);
+      const files = fs.readdirSync(tempDir);
+      const jsonReport = files.find(
+        (f) => f.startsWith('report-') && f.endsWith('.json'),
+      );
+      expect(jsonReport).toBeDefined();
+      const content = fs.readFileSync(
+        path.join(tempDir, jsonReport as string),
+        'utf8',
+      );
+      const parsed = JSON.parse(content) as Record<string, unknown>;
+      assertSnykTestJsonReport(parsed, projectRoot);
 
-    // TODO: assert HTML report exists (requires snyk-to-html binary compatible with platform)
-    // TODO: assert tl.setResult was called with Succeeded
-  }, 120_000);
+      const htmlReport = (jsonReport as string).replace(/\.json$/i, '.html');
+      expect(fs.existsSync(path.join(tempDir, htmlReport))).toBe(true);
+      const html = fs.readFileSync(path.join(tempDir, htmlReport), 'utf8');
+      assertSnykTestHtmlReport(html, projectRoot, pkg.name as string);
 
-  // TODO: test with a custom CLI path via SNYK_CLI_PATH env var
+      expect(setResultSpy).toHaveBeenCalledWith(
+        apTask.TaskResult.Succeeded,
+        'Snyk Scan completed',
+      );
+    } finally {
+      setResultSpy.mockRestore();
+    }
+  }, 60_000);
 });
 
 function trimArtifactsPath(value: unknown): string {

--- a/snykTask/src/__tests__/__integration__/integration-helpers.ts
+++ b/snykTask/src/__tests__/__integration__/integration-helpers.ts
@@ -15,22 +15,11 @@ const SNYK_TASK_ROOT = path.resolve(__dirname, '../../..');
 export const COMPILED_TASK_JS = path.join(SNYK_TASK_ROOT, 'dist', 'index.js');
 export const REPO_ROOT_FOR_SNYK_TEST = path.resolve(SNYK_TASK_ROOT, '..');
 
-export function assertSnykTestJsonReport(
-  parsed: Record<string, unknown>,
-  expectedProjectRoot: string,
-): void {
-  expect(parsed.ok).toBe(true);
-  expect(Array.isArray(parsed.vulnerabilities)).toBe(true);
-
-  const pkgPath = path.join(expectedProjectRoot, 'package.json');
-  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as { name?: string };
-  expect(typeof pkg.name).toBe('string');
-  expect(parsed.projectName).toBe(pkg.name);
-
-  expect(typeof parsed.path).toBe('string');
-  expect(path.normalize(parsed.path as string)).toBe(
-    path.normalize(expectedProjectRoot),
-  );
+export function assertSnykTestJsonReport(jsonString: string): void {
+  expect(typeof jsonString).toBe('string');
+  const trimmed = jsonString.trim();
+  expect(trimmed.length).toBeGreaterThan(0);
+  expect(() => JSON.parse(trimmed)).not.toThrow();
 }
 
 export function assertSnykTestHtmlReport(html: string): void {

--- a/snykTask/src/__tests__/__integration__/integration-helpers.ts
+++ b/snykTask/src/__tests__/__integration__/integration-helpers.ts
@@ -22,44 +22,22 @@ export function assertSnykTestJsonReport(
   expect(parsed.ok).toBe(true);
   expect(Array.isArray(parsed.vulnerabilities)).toBe(true);
 
-  expect(typeof parsed.org).toBe('string');
-  expect((parsed.org as string).length).toBeGreaterThan(0);
-
-  expect(parsed.packageManager).toBe('npm');
-
   const pkgPath = path.join(expectedProjectRoot, 'package.json');
   const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as { name?: string };
   expect(typeof pkg.name).toBe('string');
   expect(parsed.projectName).toBe(pkg.name);
 
-  expect(parsed.displayTargetFile).toBe('package-lock.json');
-
-  expect(typeof parsed.dependencyCount).toBe('number');
-  expect(parsed.dependencyCount as number).toBeGreaterThanOrEqual(0);
-
   expect(typeof parsed.path).toBe('string');
   expect(path.normalize(parsed.path as string)).toBe(
     path.normalize(expectedProjectRoot),
   );
-
-  expect(typeof parsed.summary).toBe('string');
-  expect((parsed.summary as string).length).toBeGreaterThan(0);
 }
 
-export function assertSnykTestHtmlReport(
-  html: string,
-  expectedProjectRoot: string,
-  expectedProjectName: string,
-): void {
-  expect(html).toMatch(/<!DOCTYPE html>/i);
-  expect(html).toContain('<title>Snyk test report</title>');
-  expect(html).toContain(
-    '<h1 class="project__header__title">Snyk test report</h1>',
-  );
-  expect(html).toContain('Package Manager</th>');
-  expect(html).toContain('<td class="meta-row-value">npm</td>');
-  expect(html).toContain(expectedProjectName);
-  expect(html).toContain(path.normalize(expectedProjectRoot));
+export function assertSnykTestHtmlReport(html: string): void {
+  expect(typeof html).toBe('string');
+  const trimmed = html.trim();
+  expect(trimmed.length).toBeGreaterThan(200);
+  expect(trimmed).toMatch(/<!DOCTYPE\s+html|<html[\s>]/i);
 }
 
 function trimArtifactsPath(value: unknown): string {
@@ -122,7 +100,8 @@ export function maybeCopyArtifactsThenRemoveTempDir(dir: string): void {
 }
 
 export function loadSnykToken(): string {
-  if (process.env.TEST_SNYK_TOKEN?.trim()) return process.env.TEST_SNYK_TOKEN.trim();
+  if (process.env.TEST_SNYK_TOKEN?.trim())
+    return process.env.TEST_SNYK_TOKEN.trim();
 
   throw new Error(
     `No credentials for integration test. Set TEST_SNYK_TOKEN before running the test.`,

--- a/snykTask/src/__tests__/__integration__/integration-helpers.ts
+++ b/snykTask/src/__tests__/__integration__/integration-helpers.ts
@@ -1,0 +1,130 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Copy integration artifacts (JSON, HTML, downloaded binaries) after each test.
+ * Use the following code to copy artifacts to a directory next to this test file:
+ * const INTEGRATION_ARTIFACTS_OUTPUT_DIR = path.join(
+ *   __dirname,
+ *   'integration-artifacts',
+ * );
+ */
+const INTEGRATION_ARTIFACTS_OUTPUT_DIR = '';
+
+const SNYK_TASK_ROOT = path.resolve(__dirname, '../../..');
+export const COMPILED_TASK_JS = path.join(SNYK_TASK_ROOT, 'dist', 'index.js');
+export const REPO_ROOT_FOR_SNYK_TEST = path.resolve(SNYK_TASK_ROOT, '..');
+
+export function assertSnykTestJsonReport(
+  parsed: Record<string, unknown>,
+  expectedProjectRoot: string,
+): void {
+  expect(parsed.ok).toBe(true);
+  expect(Array.isArray(parsed.vulnerabilities)).toBe(true);
+
+  expect(typeof parsed.org).toBe('string');
+  expect((parsed.org as string).length).toBeGreaterThan(0);
+
+  expect(parsed.packageManager).toBe('npm');
+
+  const pkgPath = path.join(expectedProjectRoot, 'package.json');
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as { name?: string };
+  expect(typeof pkg.name).toBe('string');
+  expect(parsed.projectName).toBe(pkg.name);
+
+  expect(parsed.displayTargetFile).toBe('package-lock.json');
+
+  expect(typeof parsed.dependencyCount).toBe('number');
+  expect(parsed.dependencyCount as number).toBeGreaterThanOrEqual(0);
+
+  expect(typeof parsed.path).toBe('string');
+  expect(path.normalize(parsed.path as string)).toBe(
+    path.normalize(expectedProjectRoot),
+  );
+
+  expect(typeof parsed.summary).toBe('string');
+  expect((parsed.summary as string).length).toBeGreaterThan(0);
+}
+
+export function assertSnykTestHtmlReport(
+  html: string,
+  expectedProjectRoot: string,
+  expectedProjectName: string,
+): void {
+  expect(html).toMatch(/<!DOCTYPE html>/i);
+  expect(html).toContain('<title>Snyk test report</title>');
+  expect(html).toContain(
+    '<h1 class="project__header__title">Snyk test report</h1>',
+  );
+  expect(html).toContain('Package Manager</th>');
+  expect(html).toContain('<td class="meta-row-value">npm</td>');
+  expect(html).toContain(expectedProjectName);
+  expect(html).toContain(path.normalize(expectedProjectRoot));
+}
+
+function trimArtifactsPath(value: unknown): string {
+  if (typeof value !== 'string') return '';
+  return value.trim();
+}
+
+/** Relative paths resolve against the monorepo root (same anchor as this test's Snyk project), not process.cwd(). */
+function normalizeArtifactsRoot(raw: string): string {
+  const t = raw.trim();
+  if (!t) return '';
+  return path.isAbsolute(t)
+    ? path.normalize(t)
+    : path.resolve(REPO_ROOT_FOR_SNYK_TEST, t);
+}
+
+function resolveIntegrationArtifactsRoot(): string | undefined {
+  const fromFile = trimArtifactsPath(INTEGRATION_ARTIFACTS_OUTPUT_DIR);
+  if (fromFile) {
+    return normalizeArtifactsRoot(fromFile);
+  }
+  const fromEnv = trimArtifactsPath(process.env.SNYK_INTEGRATION_ARTIFACTS_DIR);
+  if (fromEnv) {
+    return normalizeArtifactsRoot(fromEnv);
+  }
+  return undefined;
+}
+
+function ensureArtifactsDirectoryExists(resolvedRoot: string): void {
+  if (fs.existsSync(resolvedRoot)) {
+    const st = fs.statSync(resolvedRoot);
+    if (!st.isDirectory()) {
+      throw new Error(
+        `Integration artifacts path must be a directory, not a file: ${resolvedRoot}`,
+      );
+    }
+    return;
+  }
+  fs.mkdirSync(resolvedRoot, { recursive: true });
+}
+
+export function maybeCopyArtifactsThenRemoveTempDir(dir: string): void {
+  if (!dir || !fs.existsSync(dir)) return;
+
+  const copyDestRoot = resolveIntegrationArtifactsRoot();
+  if (copyDestRoot) {
+    ensureArtifactsDirectoryExists(copyDestRoot);
+    const dest = path.join(
+      copyDestRoot,
+      `run-${new Date().toISOString().replace(/[:.]/g, '-')}`,
+    );
+    fs.mkdirSync(dest, { recursive: true });
+    fs.cpSync(dir, dest, { recursive: true });
+    console.log(
+      `Integration test: copied artifacts to ${dest} (from INTEGRATION_ARTIFACTS_OUTPUT_DIR or SNYK_INTEGRATION_ARTIFACTS_DIR)`,
+    );
+  }
+
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+export function loadSnykToken(): string {
+  if (process.env.TEST_SNYK_TOKEN?.trim()) return process.env.TEST_SNYK_TOKEN.trim();
+
+  throw new Error(
+    `No credentials for integration test. Set TEST_SNYK_TOKEN before running the test.`,
+  );
+}

--- a/snykTask/src/index.ts
+++ b/snykTask/src/index.ts
@@ -490,7 +490,7 @@ const handleSnykMonitorError = (snykMonitorResult: SnykOutput) => {
     throw new SnykError(snykMonitorResult.message);
 };
 
-async function run() {
+export async function run() {
   try {
     const currentDir: string = tl.cwd(); // Azure mock framework will return empty string / undefined
     if (isDebugMode()) console.log(`currentWorkingDirectory: ${currentDir}\n`);
@@ -672,4 +672,4 @@ async function run() {
   }
 }
 
-run();
+export const runPromise = run();


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows CONTRIBUTING guidelines (adjust if your repo differs)
- [x] Commit messages are release-note ready, emphasizing _what_ changed
- [x] Includes description of changes
- [x] Risk assessment: Low
- [ ] Breaking API changes: N/A
- [x] Automated tests: `npm run test:integration` (and `test` job in CircleCI)
- [x] Manual testing: see below
- [ ] GitBook / docs: N/A

## What does this PR do?

- Adds an **end-to-end integration test** for the Snyk Azure Pipelines task: real `azure-pipelines-task-lib`, CLI download, `snyk test`, and lightweight format-only validation on the generated JSON and HTML reports (valid JSON / valid HTML, no assertions on internal structure).
- Exports `run` / `runPromise` from the task entry so the test can await async completion.
- Removes the `silent` parameter from `runSnykCLI` (unused after the `whoami` call cleanup).
- Bumps **`azure-pipelines-task-lib`** to **4.17.3** in `snykTask/package.json` (drops `deasync` native dependency).
- Adds **`test:integration`** script (compile + Jest scoped to `*.integration.test.ts` files, 120 s timeout, no coverage); excludes the `__integration__` folder from default **`test:unit`** via `jest.config.js`.
- **CircleCI:** runs `npm run test:integration` in the `test` job after unit tests, under the **`team_hammerhead-cli`** context (provides `TEST_SNYK_TOKEN`).
- Optional artifact copy via `INTEGRATION_ARTIFACTS_OUTPUT_DIR` / `SNYK_INTEGRATION_ARTIFACTS_DIR` for local inspection.

## Where should the reviewer start?

- `snykTask/src/__tests__/__integration__/index.integration.test.ts` — the E2E test
- `snykTask/src/__tests__/__integration__/integration-helpers.ts` — assertion helpers and artifact utilities
- `snykTask/src/index.ts` — `run`/`runPromise` exports and `silent` parameter removal
- `.circleci/config.yml` — integration step and context
- `jest.config.js` / root `package.json` — scripts and test path config

## How should this be manually tested?

1. `export TEST_SNYK_TOKEN=...` (or via 1Password: `TEST_SNYK_TOKEN="op://<Vault>/API Credentials/credential" op run -- npm run test:integration`)
2. `npm run test:integration`
3. Confirm CircleCI `test` job passes with `TEST_SNYK_TOKEN` set on the project (via `team_hammerhead-cli` context)

## Product update for release notes

None required (developer/CI reliability).

## Tickets

[CLI-1418](https://snyksec.atlassian.net/browse/CLI-1418)

[CLI-1418]: https://snyksec.atlassian.net/browse/CLI-1418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ