### PR TITLE
fix: Silence whoami probe

### DIFF
--- a/snykTask/src/index.ts
+++ b/snykTask/src/index.ts
@@ -466,15 +466,19 @@ async function runSnykCLI(
   command: string,
   snykToken: string,
   apiUrl?: string,
+  execOptions?: Partial<tr.IExecOptions>,
 ): Promise<number> {
   const taskArgs = new TaskArgs({ failOnIssues: false });
-  const options = getOptionsToExecuteSnykCLICommand(
-    taskArgs,
-    taskNameForAnalytics,
-    taskVersion,
-    snykToken,
-    apiUrl,
-  );
+  const options = {
+    ...getOptionsToExecuteSnykCLICommand(
+      taskArgs,
+      taskNameForAnalytics,
+      taskVersion,
+      snykToken,
+      apiUrl,
+    ),
+    ...execOptions,
+  } as tr.IExecOptions;
 
   const snykToolRunner = tl.tool(snykPath).line(command);
   return await snykToolRunner.execAsync(options);
@@ -590,8 +594,18 @@ async function run() {
       'whoami --experimental',
       snykToken,
       apiUrl,
+      { silent: true },
     );
     if (whoamiExitCode !== CLI_EXIT_CODE_SUCCESS) {
+      if (apiUrl) {
+        console.log(
+          'Snyk could not authenticate using the API URL from your service connection and your token; they may not match (for example, the wrong Snyk region). The task will continue with the default Snyk API. Review your service connection if scans still fail.',
+        );
+      } else {
+        console.log(
+          'Snyk could not verify the token (authentication check failed). Review your service connection and token if the scan fails.',
+        );
+      }
       if (isDebugMode()) {
         console.log('whoami failed, apiUrl will be unset');
       }

--- a/snykTask/src/index.ts
+++ b/snykTask/src/index.ts
@@ -466,7 +466,7 @@ async function runSnykCLI(
   command: string,
   snykToken: string,
   apiUrl?: string,
-  execOptions?: Partial<tr.IExecOptions>,
+  silent = false,
 ): Promise<number> {
   const taskArgs = new TaskArgs({ failOnIssues: false });
   const options = {
@@ -477,7 +477,7 @@ async function runSnykCLI(
       snykToken,
       apiUrl,
     ),
-    ...execOptions,
+    ...(silent ? { silent: true } : {}),
   } as tr.IExecOptions;
 
   const snykToolRunner = tl.tool(snykPath).line(command);
@@ -594,18 +594,9 @@ async function run() {
       'whoami --experimental',
       snykToken,
       apiUrl,
-      { silent: true },
+      true /* silent: connection probe only */,
     );
     if (whoamiExitCode !== CLI_EXIT_CODE_SUCCESS) {
-      if (apiUrl) {
-        console.log(
-          'Snyk could not authenticate using the API URL from your service connection and your token; they may not match (for example, the wrong Snyk region). The task will continue with the default Snyk API. Review your service connection if scans still fail.',
-        );
-      } else {
-        console.log(
-          'Snyk could not verify the token (authentication check failed). Review your service connection and token if the scan fails.',
-        );
-      }
       if (isDebugMode()) {
         console.log('whoami failed, apiUrl will be unset');
       }


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk-azure-pipelines-task/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are clear and describe _what_ changed
- [x] Includes description of changes
- [x] Risk assessment: Low
- [ ] Breaking API changes: none
- [ ] Links to automated tests covering new functionality (existing tests unchanged; behavior is logging + exec options)
- [x] Manual testing: run task with misconfigured service connection / wrong region URL and confirm log message + silent whoami

## What does this PR do?

- Runs the `snyk whoami --experimental` connection check with `silent: true` so authentication errors are not echoed as large CLI error blocks in pipeline logs.
- Extends `runSnykCLI` with optional `execOptions` so callers can override ToolRunner behavior without duplicating env/setup.
- Logs actionable messages for all users when `whoami` fails: different guidance when a custom API URL is configured vs default API only.

## Where should the reviewer start?

- `snykTask/src/index.ts` — `runSnykCLI`, `whoami` call site, and the new `console.log` branches.

## How should this be manually tested?

1. Pipeline with a Snyk service connection whose **URL** does not match the token region: confirm a short explanatory log and that the task continues (custom `SNYK_API` cleared as before).
2. Optional: invalid token with no custom URL: confirm the shorter token/auth message.
3. With `system.debug` enabled, confirm debug line `whoami failed, apiUrl will be unset` still appears when appropriate.

## What's the product update that needs to be communicated?

Azure Pipelines users see clearer guidance when the service connection URL and token don’t work together, without the previous noisy `whoami` stderr in normal logs.

## Risk assessment

**Low** — logging and ToolRunner `silent` flag only; scan flow and exit-code handling unchanged.

## Relevant tickets

[CLI-1428](https://snyksec.atlassian.net/browse/CLI-1428)

[CLI-1428]: https://snyksec.atlassian.net/browse/CLI-1428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ