### PR TITLE
fix: Order release creation before marketplace publish in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,8 +80,37 @@ jobs:
               NEXT_DEV_VERSION=0.0.1
             fi
 
+            echo "$NEXT_DEV_VERSION" > .deploy-version
+
             echo "Deploying to dev with ${NEXT_DEV_VERSION} ${AZ_ORG}"
             scripts/ci-deploy.sh $NEXT_DEV_VERSION $DEV_AZ_ORG
+
+      - run:
+          name: Verify Marketplace Validation
+          command: |
+            if [[ ! -f .deploy-version ]]; then
+              echo "No deploy version; skipping validation."
+              exit 0
+            fi
+            DEPLOY_VERSION=$(cat .deploy-version)
+            node ./ops/deploy/dist/wait-extension-valid.js \
+              "$DEV_AZ_PUBLISHER" \
+              "$DEV_AZ_EXTENSION_ID" \
+              "$DEPLOY_VERSION" \
+              "$DEV_AZURE_DEVOPS_EXT_PAT"
+
+      - run:
+          name: Install Extension into Dev Org
+          command: |
+            if [[ ! -f .deploy-version ]]; then
+              echo "No deploy version; skipping install."
+              exit 0
+            fi
+            DEPLOY_VERSION=$(cat .deploy-version)
+            npm install
+            npm run deploy:compile
+            node ./ops/deploy/dist/install-extension-to-dev-org.js "$DEPLOY_VERSION"
+            node ./scripts/recovery-task-json-dev.js
 
       - run:
           name: Create renamed copy of the vsix bundle
@@ -131,10 +160,25 @@ jobs:
             npm run deploy:compile
 
             VERSION=$(date +"%Y.%-m.%-d%H%M")
+            echo "$VERSION" > .deploy-version
             echo "Deploying to Preview: ${VERSION}"
 
             chmod +x scripts/ci-deploy-preview.sh
             scripts/ci-deploy-preview.sh $VERSION
+
+      - run:
+          name: Verify Marketplace Validation
+          command: |
+            if [[ ! -f .deploy-version ]]; then
+              echo "No deploy version; skipping validation."
+              exit 0
+            fi
+            DEPLOY_VERSION=$(cat .deploy-version)
+            node ./ops/deploy/dist/wait-extension-valid.js \
+              "$AZ_PUBLISHER" \
+              "$AZ_EXTENSION_ID" \
+              "$DEPLOY_VERSION" \
+              "$PROD_AZURE_DEVOPS_EXT_PAT"
   deploy_prod:
     docker:
       - image: circleci/node:lts
@@ -176,6 +220,20 @@ jobs:
             RELEASE_VERSION=$(cat .release-version)
             echo "Deploying version ${RELEASE_VERSION} to Marketplace..."
             scripts/ci-deploy.sh $RELEASE_VERSION
+
+      - run:
+          name: Verify Marketplace Validation
+          command: |
+            if [[ ! -f .release-version ]]; then
+              echo "No release version; skipping validation."
+              exit 0
+            fi
+            RELEASE_VERSION=$(cat .release-version)
+            node ./ops/deploy/dist/wait-extension-valid.js \
+              "$AZ_PUBLISHER" \
+              "$AZ_EXTENSION_ID" \
+              "$RELEASE_VERSION" \
+              "$PROD_AZURE_DEVOPS_EXT_PAT"
 
       - run:
           name: Create renamed copy of the vsix bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,6 @@ jobs:
             fi
             DEPLOY_VERSION=$(cat .deploy-version)
             npm install
-            npm run deploy:compile
             node ./ops/deploy/dist/install-extension-to-dev-org.js "$DEPLOY_VERSION"
             node ./scripts/recovery-task-json-dev.js
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,6 +217,7 @@ jobs:
               exit 0
             fi
             export AZURE_DEVOPS_EXT_PAT=$PROD_AZURE_DEVOPS_EXT_PAT
+            npm run deploy:compile
             RELEASE_VERSION=$(cat .release-version)
             echo "Deploying version ${RELEASE_VERSION} to Marketplace..."
             scripts/ci-deploy.sh $RELEASE_VERSION

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,12 +92,12 @@ jobs:
               echo "No deploy version; skipping validation."
               exit 0
             fi
+            export AZURE_DEVOPS_EXT_PAT="$DEV_AZURE_DEVOPS_EXT_PAT"
             DEPLOY_VERSION=$(cat .deploy-version)
             node ./ops/deploy/dist/wait-extension-valid.js \
               "$DEV_AZ_PUBLISHER" \
               "$DEV_AZ_EXTENSION_ID" \
-              "$DEPLOY_VERSION" \
-              "$DEV_AZURE_DEVOPS_EXT_PAT"
+              "$DEPLOY_VERSION"
 
       - run:
           name: Install Extension into Dev Org
@@ -173,12 +173,12 @@ jobs:
               echo "No deploy version; skipping validation."
               exit 0
             fi
+            export AZURE_DEVOPS_EXT_PAT="$PROD_AZURE_DEVOPS_EXT_PAT"
             DEPLOY_VERSION=$(cat .deploy-version)
             node ./ops/deploy/dist/wait-extension-valid.js \
               "$AZ_PUBLISHER" \
               "$AZ_EXTENSION_ID" \
-              "$DEPLOY_VERSION" \
-              "$PROD_AZURE_DEVOPS_EXT_PAT"
+              "$DEPLOY_VERSION"
   deploy_prod:
     docker:
       - image: circleci/node:lts
@@ -229,12 +229,12 @@ jobs:
               echo "No release version; skipping validation."
               exit 0
             fi
+            export AZURE_DEVOPS_EXT_PAT="$PROD_AZURE_DEVOPS_EXT_PAT"
             RELEASE_VERSION=$(cat .release-version)
             node ./ops/deploy/dist/wait-extension-valid.js \
               "$AZ_PUBLISHER" \
               "$AZ_EXTENSION_ID" \
-              "$RELEASE_VERSION" \
-              "$PROD_AZURE_DEVOPS_EXT_PAT"
+              "$RELEASE_VERSION"
 
       - run:
           name: Create renamed copy of the vsix bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,10 +160,22 @@ jobs:
             npm run build:clean
 
       - run:
-          name: Create Extension
+          name: Create Release
           command: |
             export AZURE_DEVOPS_EXT_PAT=$PROD_AZURE_DEVOPS_EXT_PAT
             npx semantic-release
+
+      - run:
+          name: Deploy to Marketplace
+          command: |
+            if [[ ! -f .release-version ]]; then
+              echo "No new release version detected; skipping Marketplace deploy."
+              exit 0
+            fi
+            export AZURE_DEVOPS_EXT_PAT=$PROD_AZURE_DEVOPS_EXT_PAT
+            RELEASE_VERSION=$(cat .release-version)
+            echo "Deploying version ${RELEASE_VERSION} to Marketplace..."
+            scripts/ci-deploy.sh $RELEASE_VERSION
 
       - run:
           name: Create renamed copy of the vsix bundle

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ ops/deploy/dist
 .cursor
 .env
 .release-version
+.deploy-version

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ snykTask/coverage
 .ops
 ops/deploy/dist
 .cursor
+.env
+.release-version

--- a/.releaserc
+++ b/.releaserc
@@ -4,10 +4,13 @@
   ],
   "repositoryUrl": "https://github.com/snyk/snyk-azure-pipelines-task",
   "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/changelog",
     [
       "@semantic-release/exec",
       {
-        "publishCmd": "scripts/ci-deploy.sh ${nextRelease.version}"
+        "prepareCmd": "echo ${nextRelease.version} > .release-version"
       }
     ],
     [
@@ -17,9 +20,6 @@
         "message": "chore(release): ${nextRelease.version}"
       }
     ],
-    "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
-    "@semantic-release/changelog",
     "@semantic-release/github"
   ]
 }

--- a/ops/deploy/wait-extension-valid.ts
+++ b/ops/deploy/wait-extension-valid.ts
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026 Snyk Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as GalleryInterfaces from 'azure-devops-node-api/interfaces/GalleryInterfaces';
+
+import { getExtensionInfo } from './lib/azure-devops';
+import { asyncSleep } from './lib/sleep';
+
+const TIMEOUT_MS = parseInt(process.env.VALIDATION_TIMEOUT_MS || '600000', 10);
+const POLL_MS = parseInt(process.env.VALIDATION_POLL_MS || '15000', 10);
+
+type ValidationResult =
+  | { status: 'validated' }
+  | { status: 'pending' }
+  | { status: 'error'; message: string };
+
+async function checkValidation(
+  azToken: string,
+  publisher: string,
+  extensionId: string,
+  version: string,
+): Promise<ValidationResult> {
+  const extensionDetails = await getExtensionInfo(
+    azToken,
+    publisher,
+    extensionId,
+  );
+
+  if (!extensionDetails || !extensionDetails.versions) {
+    return { status: 'error', message: 'Extension or versions not found.' };
+  }
+
+  const matchingVersion = (
+    extensionDetails.versions as GalleryInterfaces.ExtensionVersion[]
+  ).find((v) => v.version === version);
+
+  if (!matchingVersion) {
+    return {
+      status: 'pending',
+    };
+  }
+
+  if (
+    matchingVersion.flags !== undefined &&
+    (matchingVersion.flags & GalleryInterfaces.ExtensionVersionFlags.Validated) !==
+      0
+  ) {
+    return { status: 'validated' };
+  }
+
+  if (matchingVersion.validationResultMessage) {
+    return {
+      status: 'error',
+      message: matchingVersion.validationResultMessage,
+    };
+  }
+
+  return { status: 'pending' };
+}
+
+async function main() {
+  const publisher = process.argv[2];
+  const extensionId = process.argv[3];
+  const version = process.argv[4];
+  const azToken = process.argv[5] || process.env.AZURE_DEVOPS_EXT_PAT || '';
+
+  if (!publisher || !extensionId || !version) {
+    console.error(
+      'Usage: wait-extension-valid <publisher> <extensionId> <version> [token]',
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `Waiting for Marketplace validation of ${publisher}.${extensionId}@${version} (timeout: ${TIMEOUT_MS / 1000}s, poll: ${POLL_MS / 1000}s)...`,
+  );
+
+  const deadline = Date.now() + TIMEOUT_MS;
+
+  while (Date.now() < deadline) {
+    try {
+      const result = await checkValidation(
+        azToken,
+        publisher,
+        extensionId,
+        version,
+      );
+
+      if (result.status === 'validated') {
+        console.log('Extension validated successfully.');
+        process.exit(0);
+      }
+
+      if (result.status === 'error') {
+        console.error(`Marketplace validation failed: ${result.message}`);
+        process.exit(1);
+      }
+
+      const elapsed = Math.round((TIMEOUT_MS - (deadline - Date.now())) / 1000);
+      console.log(
+        `  Validation pending... (${elapsed}s / ${TIMEOUT_MS / 1000}s)`,
+      );
+    } catch (err) {
+      console.warn(`  Warning: validation check failed, retrying... (${err})`);
+    }
+
+    await asyncSleep(POLL_MS);
+  }
+
+  console.error(
+    `Timed out after ${TIMEOUT_MS / 1000}s waiting for validation.`,
+  );
+  process.exit(1);
+}
+
+if (require.main === module) {
+  main();
+}

--- a/ops/deploy/wait-extension-valid.ts
+++ b/ops/deploy/wait-extension-valid.ts
@@ -56,7 +56,7 @@ async function checkValidation(
   );
 
   if (!extensionDetails || !extensionDetails.versions) {
-    return { status: 'error', message: 'Extension or versions not found.' };
+    return { status: 'pending' };
   }
 
   const matchingVersion = (
@@ -92,12 +92,17 @@ async function main() {
   const publisher = process.argv[2];
   const extensionId = process.argv[3];
   const version = process.argv[4];
-  const azToken = process.argv[5] || process.env.AZURE_DEVOPS_EXT_PAT || '';
+  const azToken = process.env.AZURE_DEVOPS_EXT_PAT || '';
 
   if (!publisher || !extensionId || !version) {
     console.error(
-      'Usage: wait-extension-valid <publisher> <extensionId> <version> [token]',
+      'Usage: wait-extension-valid <publisher> <extensionId> <version>',
     );
+    process.exit(1);
+  }
+
+  if (!azToken) {
+    console.error('AZURE_DEVOPS_EXT_PAT environment variable is not set.');
     process.exit(1);
   }
 

--- a/ops/deploy/wait-extension-valid.ts
+++ b/ops/deploy/wait-extension-valid.ts
@@ -32,7 +32,7 @@ function getHttpStatus(err: unknown): number | undefined {
   return undefined;
 }
 
-const RETRYABLE_STATUS_CODES = new Set([408, 429]);
+const RETRYABLE_STATUS_CODES = new Set([404, 408, 429]);
 
 function isRetryableError(statusCode: number): boolean {
   return statusCode >= 500 || RETRYABLE_STATUS_CODES.has(statusCode);

--- a/ops/deploy/wait-extension-valid.ts
+++ b/ops/deploy/wait-extension-valid.ts
@@ -22,6 +22,22 @@ import { asyncSleep } from './lib/sleep';
 const TIMEOUT_MS = parseInt(process.env.VALIDATION_TIMEOUT_MS || '600000', 10);
 const POLL_MS = parseInt(process.env.VALIDATION_POLL_MS || '15000', 10);
 
+function getHttpStatus(err: unknown): number | undefined {
+  if (err && typeof err === 'object' && 'statusCode' in err) {
+    const code = (err as { statusCode?: number }).statusCode;
+    if (typeof code === 'number' && Number.isFinite(code)) {
+      return code;
+    }
+  }
+  return undefined;
+}
+
+const RETRYABLE_STATUS_CODES = new Set([408, 429]);
+
+function isRetryableError(statusCode: number): boolean {
+  return statusCode >= 500 || RETRYABLE_STATUS_CODES.has(statusCode);
+}
+
 type ValidationResult =
   | { status: 'validated' }
   | { status: 'pending' }
@@ -55,7 +71,8 @@ async function checkValidation(
 
   if (
     matchingVersion.flags !== undefined &&
-    (matchingVersion.flags & GalleryInterfaces.ExtensionVersionFlags.Validated) !==
+    (matchingVersion.flags &
+      GalleryInterfaces.ExtensionVersionFlags.Validated) !==
       0
   ) {
     return { status: 'validated' };
@@ -85,7 +102,9 @@ async function main() {
   }
 
   console.log(
-    `Waiting for Marketplace validation of ${publisher}.${extensionId}@${version} (timeout: ${TIMEOUT_MS / 1000}s, poll: ${POLL_MS / 1000}s)...`,
+    `Waiting for Marketplace validation of ${publisher}.${extensionId}@${version} (timeout: ${
+      TIMEOUT_MS / 1000
+    }s, poll: ${POLL_MS / 1000}s)...`,
   );
 
   const deadline = Date.now() + TIMEOUT_MS;
@@ -114,7 +133,16 @@ async function main() {
         `  Validation pending... (${elapsed}s / ${TIMEOUT_MS / 1000}s)`,
       );
     } catch (err) {
-      console.warn(`  Warning: validation check failed, retrying... (${err})`);
+      const status = getHttpStatus(err);
+      if (status !== undefined && !isRetryableError(status)) {
+        console.error(
+          `Gallery API error (HTTP ${status}); not retrying: ${err}`,
+        );
+        process.exit(1);
+      }
+      const label =
+        status !== undefined ? `HTTP ${status} (transient)` : 'unknown error';
+      console.warn(`  ${label}: ${err}; retrying...`);
     }
 
     await asyncSleep(POLL_MS);

--- a/scripts/ci-deploy-dev.sh
+++ b/scripts/ci-deploy-dev.sh
@@ -90,10 +90,8 @@ ls -la snykTask/dist
 echo "checking snykTask/node_modules..."
 ls -la snykTask/node_modules
 
-# Publishing and sharing extension (--no-wait-validation: don't block on Marketplace validation)
+# Publishing and sharing extension
 echo "Publishing and sharing extension..."
-echo "To manually check validation status, run:"
-echo "  tfx extension isvalid --publisher ${DEV_AZ_PUBLISHER} --extension-id ${DEV_AZ_EXTENSION_ID} --version ${INPUT_PARAM_AZ_EXT_NEW_VERSION} --service-url https://marketplace.visualstudio.com/ --token <PAT>"
 echo "OVERRIDE_JSON: ${OVERRIDE_JSON}"
 echo "About to call \`tfx extension publish...\`"
 
@@ -103,8 +101,7 @@ tfx extension publish --manifest-globs vss-extension-dev.json \
 --extension-id $DEV_AZ_EXTENSION_ID \
 --publisher $DEV_AZ_PUBLISHER \
 --override $OVERRIDE_JSON \
---token $DEV_AZURE_DEVOPS_EXT_PAT \
---no-wait-validation
+--token $DEV_AZURE_DEVOPS_EXT_PAT
 
 publish_exit_code=$?
 if [[ publish_exit_code -eq 0 ]]; then

--- a/scripts/ci-deploy-dev.sh
+++ b/scripts/ci-deploy-dev.sh
@@ -90,8 +90,10 @@ ls -la snykTask/dist
 echo "checking snykTask/node_modules..."
 ls -la snykTask/node_modules
 
-# Publishing and sharing extension
+# Publishing and sharing extension (--no-wait-validation: don't block on Marketplace validation)
 echo "Publishing and sharing extension..."
+echo "To manually check validation status, run:"
+echo "  tfx extension isvalid --publisher ${DEV_AZ_PUBLISHER} --extension-id ${DEV_AZ_EXTENSION_ID} --version ${INPUT_PARAM_AZ_EXT_NEW_VERSION} --service-url https://marketplace.visualstudio.com/ --token <PAT>"
 echo "OVERRIDE_JSON: ${OVERRIDE_JSON}"
 echo "About to call \`tfx extension publish...\`"
 
@@ -101,7 +103,8 @@ tfx extension publish --manifest-globs vss-extension-dev.json \
 --extension-id $DEV_AZ_EXTENSION_ID \
 --publisher $DEV_AZ_PUBLISHER \
 --override $OVERRIDE_JSON \
---token $DEV_AZURE_DEVOPS_EXT_PAT
+--token $DEV_AZURE_DEVOPS_EXT_PAT \
+--no-wait-validation
 
 publish_exit_code=$?
 if [[ publish_exit_code -eq 0 ]]; then

--- a/scripts/ci-deploy-dev.sh
+++ b/scripts/ci-deploy-dev.sh
@@ -101,7 +101,8 @@ tfx extension publish --manifest-globs vss-extension-dev.json \
 --extension-id $DEV_AZ_EXTENSION_ID \
 --publisher $DEV_AZ_PUBLISHER \
 --override $OVERRIDE_JSON \
---token $DEV_AZURE_DEVOPS_EXT_PAT
+--token $DEV_AZURE_DEVOPS_EXT_PAT \
+--no-wait-validation
 
 publish_exit_code=$?
 if [[ publish_exit_code -eq 0 ]]; then
@@ -110,19 +111,3 @@ else
   echo "Extension failed to pubish with exit code ${publish_exit_code}"
   exit ${publish_exit_code}
 fi
-
-# re-install all dependencies. The dev deps were pruned off in ci-build.sh
-echo "reinstalling all dependencies..."
-npm install
-
-echo "Run script to install the dev extension into the dev org in Azure DevOps..."
-node ./ops/deploy/dist/install-extension-to-dev-org.js "${INPUT_PARAM_AZ_EXT_NEW_VERSION}"
-if [[ ! $? -eq 0 ]]; then
-  echo "failed installing dev extension at correct version"
-  exit 1
-fi
-
-# Updating version in task.json file
-node "${PWD}/scripts/recovery-task-json-dev.js"
-
-echo "Extension installed"

--- a/scripts/ci-deploy-preview.sh
+++ b/scripts/ci-deploy-preview.sh
@@ -45,12 +45,16 @@ echo "Extension ID: ${AZ_EXTENSION_ID}"
 echo "Publisher: ${AZ_PUBLISHER}"
 echo "Override JSON: ${OVERRIDE_JSON}"
 
+# --no-wait-validation: don't block on Marketplace validation
+echo "To manually check validation status, run:"
+echo "  tfx extension isvalid --publisher ${AZ_PUBLISHER} --extension-id ${AZ_EXTENSION_ID} --version ${AZ_EXT_NEW_VERSION} --service-url https://marketplace.visualstudio.com/ --token <PAT>"
 tfx extension publish --manifest-globs vss-extension-preview.json \
 --version $AZ_EXT_NEW_VERSION \
 --extension-id $AZ_EXTENSION_ID \
 --publisher $AZ_PUBLISHER \
 --override $OVERRIDE_JSON \
---token $AZURE_DEVOPS_EXT_PAT
+--token $AZURE_DEVOPS_EXT_PAT \
+--no-wait-validation
 
 publish_exit_code=$?
 if [[ publish_exit_code -eq 0 ]]; then

--- a/scripts/ci-deploy-preview.sh
+++ b/scripts/ci-deploy-preview.sh
@@ -45,9 +45,6 @@ echo "Extension ID: ${AZ_EXTENSION_ID}"
 echo "Publisher: ${AZ_PUBLISHER}"
 echo "Override JSON: ${OVERRIDE_JSON}"
 
-# --no-wait-validation: don't block on Marketplace validation
-echo "To manually check validation status, run:"
-echo "  tfx extension isvalid --publisher ${AZ_PUBLISHER} --extension-id ${AZ_EXTENSION_ID} --version ${AZ_EXT_NEW_VERSION} --service-url https://marketplace.visualstudio.com/ --token <PAT>"
 tfx extension publish --manifest-globs vss-extension-preview.json \
 --version $AZ_EXT_NEW_VERSION \
 --extension-id $AZ_EXTENSION_ID \

--- a/scripts/ci-deploy-prod.sh
+++ b/scripts/ci-deploy-prod.sh
@@ -29,10 +29,8 @@ node "${PWD}/scripts/ci-update-task-json-prod.js" ${AZ_EXT_NEW_VERSION}
 # Override version
 OVERRIDE_JSON="{ \"id\": \"${AZ_EXTENSION_ID}\", \"name\": \"${AZ_EXTENSION_NAME}\", \"version\": \"${AZ_EXT_NEW_VERSION}\", \"public\": true }"
 
-# Publish extension (--no-wait-validation: don't block on Marketplace validation)
+# Publish extension
 echo "Publishing extension..."
-echo "To manually check validation status, run:"
-echo "  tfx extension isvalid --publisher ${AZ_PUBLISHER} --extension-id ${AZ_EXTENSION_ID} --version ${AZ_EXT_NEW_VERSION} --service-url https://marketplace.visualstudio.com/ --token <PAT>"
 tfx extension publish --manifest-globs vss-extension.json \
 --version $AZ_EXT_NEW_VERSION \
 --extension-id $AZ_EXTENSION_ID \

--- a/scripts/ci-deploy-prod.sh
+++ b/scripts/ci-deploy-prod.sh
@@ -29,14 +29,17 @@ node "${PWD}/scripts/ci-update-task-json-prod.js" ${AZ_EXT_NEW_VERSION}
 # Override version
 OVERRIDE_JSON="{ \"id\": \"${AZ_EXTENSION_ID}\", \"name\": \"${AZ_EXTENSION_NAME}\", \"version\": \"${AZ_EXT_NEW_VERSION}\", \"public\": true }"
 
-# Publish extension
+# Publish extension (--no-wait-validation: don't block on Marketplace validation)
 echo "Publishing extension..."
+echo "To manually check validation status, run:"
+echo "  tfx extension isvalid --publisher ${AZ_PUBLISHER} --extension-id ${AZ_EXTENSION_ID} --version ${AZ_EXT_NEW_VERSION} --service-url https://marketplace.visualstudio.com/ --token <PAT>"
 tfx extension publish --manifest-globs vss-extension.json \
 --version $AZ_EXT_NEW_VERSION \
 --extension-id $AZ_EXTENSION_ID \
 --publisher $AZ_PUBLISHER \
 --override $OVERRIDE_JSON \
---token $AZURE_DEVOPS_EXT_PAT
+--token $AZURE_DEVOPS_EXT_PAT \
+--no-wait-validation
 
 publish_exit_code=$?
 if [[ publish_exit_code -eq 0 ]]; then


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ changed, not _how_
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Stops Marketplace publishing from running inside semantic-release’s `publish` step (so GitHub release creation is not blocked by slow or failing `tfx` validation).

- Writes the release version to `.release-version` via `@semantic-release/exec` `prepareCmd`.
- Adds a **Deploy to Marketplace** CircleCI step **after** `npx semantic-release`, which runs `scripts/ci-deploy.sh` using that version.
- Uses `--no-wait-validation` on `tfx extension publish` for dev, preview, and prod so publish returns without blocking on Marketplace validation.
- Adds a dedicated **Verify Marketplace Validation** CircleCI step (dev, preview, and prod) that runs `ops/deploy/wait-extension-valid.ts` (compiled to `ops/deploy/dist/wait-extension-valid.js`), polling the Gallery API until the published version is validated or failing on error/timeout. Prod/preview skip validation when there is no release/deploy version file, consistent with skipping deploy.
- For **dev**, splits post-publish work into separate CircleCI steps: publish (via existing `ci-deploy` path) → **Verify Marketplace Validation** → **Install Extension into Dev Org** (moved out of `ci-deploy-dev.sh`), so the non-blocking publish does not regress the prior `TF1590010` install race.
- Writes the dev deploy version to `.deploy-version` for those steps; ignores `.deploy-version` in `.gitignore`.
- Drops the copy-paste `tfx extension isvalid` echo hints from preview/prod deploy scripts; automated validation replaces them.
- Ignores `.release-version` in `.gitignore`.

## Where should the reviewer start?

- `.releaserc`
- `.circleci/config.yml` (`deploy_dev`, `deploy_preview`, `deploy_prod`)
- `ops/deploy/wait-extension-valid.ts`
- `scripts/ci-deploy-dev.sh`, `scripts/ci-deploy-preview.sh`, `scripts/ci-deploy-prod.sh`
- `.gitignore`

## How should this be manually tested?

1. On a branch where `deploy_prod` can run: confirm `npx semantic-release` completes and the GitHub release is created.
2. Confirm **Deploy to Marketplace** runs when `.release-version` exists, and skips when there is no new release.
3. Confirm **Verify Marketplace Validation** runs after publish for dev/preview/prod and fails the job if validation never succeeds.
4. On a non-`main` branch with dev deploy: confirm CircleCI shows separate steps for deploy, validation, and install, and the pipeline completes without the extension install race.

## What's the product update that needs to be communicated to CLI users?

None. Release/CI pipeline behaviour only.

## Risk assessment (Low | Medium | High)?

Low

## What are the relevant tickets?

[CLI-1426](https://snyksec.atlassian.net/browse/CLI-1426)

[CLI-1426]: https://snyksec.atlassian.net/browse/CLI-1426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ