### PR TITLE
chore: Run marketplace deploy after GitHub release in semantic-release

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -5,12 +5,6 @@
   "repositoryUrl": "https://github.com/snyk/snyk-azure-pipelines-task",
   "plugins": [
     [
-      "@semantic-release/exec",
-      {
-        "publishCmd": "scripts/ci-deploy.sh ${nextRelease.version}"
-      }
-    ],
-    [
       "@semantic-release/git",
       {
         "assets": [],
@@ -20,6 +14,12 @@
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
-    "@semantic-release/github"
+    "@semantic-release/github",
+    [
+      "@semantic-release/exec",
+      {
+        "publishCmd": "scripts/ci-deploy.sh ${nextRelease.version}"
+      }
+    ]
   ]
 }


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Moves the `@semantic-release/exec` plugin (which runs `scripts/ci-deploy.sh`) to the end of the `plugins` array in `.releaserc`, after `@semantic-release/github`. Publish plugins run in order, so the GitHub release is created before the deploy command runs.

## Where should the reviewer start?

- `.releaserc` — plugin order only

## How should this be manually tested?

1. After merge, run a release (or validate semantic-release config / dry-run if your process supports it) and confirm publish order: GitHub release first, then deploy script.
2. No runtime change to the Azure Pipelines task itself.

## What's the product update that needs to be communicated to CLI users?

None. Release pipeline ordering only.

## Risk assessment (Low | Medium | High)?

Low — configuration-only change.

## Any background context you want to provide?

Previously `exec` ran before `github` in the plugin list. This aligns order with “GitHub release first, then marketplace / deploy.”

## What are the relevant tickets?

[CLI-1426](https://snyksec.atlassian.net/browse/CLI-1426)

## Screenshots (if appropriate)

N/A

[CLI-1426]: https://snyksec.atlassian.net/browse/CLI-1426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ