### PR TITLE
chore: Remove redundant uninstall/install steps from dev deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,12 @@ jobs:
           path: ./dev-extension-artifact.vsix
 
       - run:
+          name: Wait for extension availability
+          command: |
+            echo "Sleeping 60s to let Azure DevOps propagate the updated extension..."
+            sleep 60
+
+      - run:
           name: Launch Test Pipelines
           command: |
             node ./ops/deploy/dist/run-test-pipelines.js

--- a/scripts/ci-deploy-dev.sh
+++ b/scripts/ci-deploy-dev.sh
@@ -49,26 +49,6 @@ if [[ ! $? -eq 0 ]]; then
   fi
 fi
 
-# echo "See if the extension is installed..."
-az devops extension show \
-  --publisher-name $DEV_AZ_PUBLISHER \
-  --extension-name $DEV_AZ_EXTENSION_ID \
-  --organization "https://dev.azure.com/${INPUT_PARAM_AZ_ORG}/"
-
-if [[ $? -eq 0 ]]; then
-  echo "Extension is installed in org ${INPUT_PARAM_AZ_ORG}... uninstall it"
-  # Unistall the extinsion if it has been already installed in this organization.
-  # This may not be required it works much more consistently with it.
-  echo "Uninstall extension..."
-  az devops extension uninstall \
-    --publisher-name $DEV_AZ_PUBLISHER \
-    --extension-name $DEV_AZ_EXTENSION_ID \
-    --organization "https://dev.azure.com/${INPUT_PARAM_AZ_ORG}/" --yes
-  echo "Extension uninstalled"
-else
-  echo "Extension not already installed."
-fi
-
 echo "About to deploy to dev environment using:"
 echo "INPUT_PARAM_AZ_EXT_NEW_VERSION: ${INPUT_PARAM_AZ_EXT_NEW_VERSION}"
 echo "DEV_AZ_PUBLISHER: ${DEV_AZ_PUBLISHER}"
@@ -111,18 +91,7 @@ else
   exit ${publish_exit_code}
 fi
 
-# re-install all dependencies. The dev deps were pruned off in ci-build.sh
-echo "reinstalling all dependencies..."
-npm install
-
-echo "Run script to install the dev extension into the dev org in Azure DevOps..."
-node ./ops/deploy/dist/install-extension-to-dev-org.js "${INPUT_PARAM_AZ_EXT_NEW_VERSION}"
-if [[ ! $? -eq 0 ]]; then
-  echo "failed installing dev extension at correct version"
-  exit 1
-fi
-
 # Updating version in task.json file
 node "${PWD}/scripts/recovery-task-json-dev.js"
 
-echo "Extension installed"
+echo "Extension published and shared successfully"


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Removes the redundant `az devops extension uninstall` and `install-extension-to-dev-org.js` steps from `ci-deploy-dev.sh`. These are unnecessary because `tfx extension publish --share-with` auto-updates already-installed extensions in the org. The uninstall/install cycle was causing 409 / TF1590010 ("already installed") race conditions that marked CI as failed even though the extension was successfully published.

`install-extension-to-dev-org.ts` is left intact for manual / first-time use.

Adds a 30-second delay before "Launch Test Pipelines" to allow Azure DevOps to propagate the updated extension. Previously this delay came from the `install-extension-to-dev-org.js` step (which slept 30s after installing). Without it, test pipelines can fail with "Could not queue the build because there were validation errors or warnings" because the extension isn't fully available yet.

## Where should the reviewer start?

- `scripts/ci-deploy-dev.sh` — removed uninstall block and install-to-org block
- `.circleci/config.yml` — new "Wait for extension availability" step before "Launch Test Pipelines"

## How should this be manually tested?

1. Push a branch, confirm `deploy_dev` CI job succeeds without running uninstall or install-extension-to-dev-org.js.
2. Verify the dev extension is updated in the Azure DevOps org after publish.

## What's the product update that needs to be communicated to CLI users?

None. Internal CI pipeline change only.

## Risk assessment (Low | Medium | High)?

Low — removes steps that were redundant with `tfx publish --share-with` behavior.

## Any background context you want to provide?

`tfx extension publish --share-with` auto-updates extensions already installed in a shared org. The explicit uninstall + `installExtensionByName` cycle was a workaround that introduced eventual-consistency races (409 errors). Removing both eliminates the root cause of flaky dev deploy CI runs.

## What are the relevant tickets?

[CLI-1435](https://snyksec.atlassian.net/browse/CLI-1435)
[CLI-1426](https://snyksec.atlassian.net/browse/CLI-1426)

[CLI-1435]: https://snyksec.atlassian.net/browse/CLI-1435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ