### PR TITLE
chore: update dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
 
   test:
     docker:
-      - image: circleci/node:lts
+      - image: cimg/node:lts
     working_directory: ~/repo
     steps:
       - checkout
@@ -141,7 +141,7 @@ jobs:
             scripts/ci-deploy-preview.sh $VERSION
   deploy_prod:
     docker:
-      - image: circleci/node:lts
+      - image: cimg/node:lts
         environment:
           AZ_EXTENSION_ID: 'snyk-security-scan'
           AZ_EXTENSION_NAME: 'Snyk Security Scan'

--- a/snykTask/package-lock.json
+++ b/snykTask/package-lock.json
@@ -73,9 +73,10 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -170,15 +171,16 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -705,9 +707,9 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -773,9 +775,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -911,7 +913,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.15"
       }
     },
     "ms": {
@@ -924,7 +926,7 @@
       "resolved": "https://registry.npmjs.org/nodejs-file-downloader/-/nodejs-file-downloader-4.13.0.tgz",
       "integrity": "sha512-nI2fKnmJWWFZF6SgMPe1iBodKhfpztLKJTtCtNYGhm/9QXmWa/Pk9Sv00qHgzEvNLe1x7hjGDRor7gcm/ChaIQ==",
       "requires": {
-        "follow-redirects": "^1.15.6",
+        "follow-redirects": "1.16.0",
         "https-proxy-agent": "^5.0.0",
         "mime-types": "^2.1.27",
         "sanitize-filename": "^1.6.3"

--- a/snykTask/package.json
+++ b/snykTask/package.json
@@ -6,6 +6,8 @@
   "overrides": {
     "azure-pipelines-task-lib": {
       "minimatch@3.0.5": "3.1.5"
-    }
+    },
+    "brace-expansion": "1.1.15",
+    "follow-redirects": "1.16.0"
   }
 }


### PR DESCRIPTION
# Summary
- Override brace-expansion to 1.1.15 in snykTask
- Override follow-redirects to 1.16.0 in snykTask 
- Update CircleCI test and deploy_prod jobs from circleci/node:lts to cimg/node:lts 

The packages are transitive dependencies introduced by azure-pipelines-task-lib@4.17.3. `brace-expansion` through `minimatch`, and `follow-redirects` through `nodejs-file-downloader`. Since 4.17.3 is already the latest 4.x, there is no in-range upgrade available for the direct dependency.

The two alternative fixes were ruled out on Node 10 compatibility grounds:

Upgrading azure-pipelines-task-lib to 5.x — 5.x depends on shelljs@^0.10.0, which declares engines: { node: ">=18" }.
Upgrading azure-pipelines-tool-lib to 2.0.12 — that version declares azure-pipelines-task-lib@^5.2.7 as a dependency, so npm would nest a copy of task-lib 5.x inside it, pulling in the same shelljs@0.10.0 constraint.
Using overrides forces the fixed versions of the two packages across the entire dependency tree without touching the direct dependencies or their Node version requirements.


Relevant tickets: [CLI-1542](https://snyksec.atlassian.net/browse/CLI-1542)

[CLI-1542]: https://snyksec.atlassian.net/browse/CLI-1542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ