### PR TITLE
fix: upgrade follow-redirects to 1.16.0 to strip sensitive headers

### DIFF
--- a/snykTask/package-lock.json
+++ b/snykTask/package-lock.json
@@ -170,15 +170,16 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -773,9 +774,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -924,7 +925,7 @@
       "resolved": "https://registry.npmjs.org/nodejs-file-downloader/-/nodejs-file-downloader-4.13.0.tgz",
       "integrity": "sha512-nI2fKnmJWWFZF6SgMPe1iBodKhfpztLKJTtCtNYGhm/9QXmWa/Pk9Sv00qHgzEvNLe1x7hjGDRor7gcm/ChaIQ==",
       "requires": {
-        "follow-redirects": "^1.15.6",
+        "follow-redirects": "1.16.0",
         "https-proxy-agent": "^5.0.0",
         "mime-types": "^2.1.27",
         "sanitize-filename": "^1.6.3"

--- a/snykTask/package.json
+++ b/snykTask/package.json
@@ -4,6 +4,7 @@
     "azure-pipelines-tool-lib": "2.0.8"
   },
   "overrides": {
+    "follow-redirects": "1.16.0",
     "azure-pipelines-task-lib": {
       "minimatch@3.0.5": "3.1.5"
     }


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Resolves CVE-2026-40895 (CWE-212, CVSS 7.7) by forcing the transitive
`follow-redirects` dependency to the patched version `1.16.0`. The vulnerable
`1.15.6` was pulled in via `azure-pipelines-tool-lib` -> `nodejs-file-downloader`,
which could forward custom authentication headers to an attacker-controlled
domain on cross-domain redirects.

Since `follow-redirects` is not a direct dependency, the fix is applied through
an npm `override` in `snykTask/package.json` (consistent with existing overrides
in this file), and the lockfile is regenerated accordingly.

## Where should the reviewer start?

- `snykTask/package.json` - added `follow-redirects: "1.16.0"` override
- `snykTask/package-lock.json` - regenerated, resolves follow-redirects to 1.16.0

## How should this be manually tested?

1. `cd snykTask && npm install`
2. `npm ls follow-redirects` - confirm it resolves to `1.16.0`
3. From repo root, run `npm run test:unit` - existing tests should pass

## What's the product update that needs to be communicated to CLI users?

None. Internal transitive dependency security bump with no user-facing behavior change.

<!---
## Risk assessment (Low | Medium | High)?

Low. Minor version bump (1.15.6 -> 1.16.0) satisfying the existing `^1.15.6`
range. The only code path reaching this package downloads public Snyk binaries
with no auth headers, so header-stripping has no functional impact. No tests
exercise cross-domain redirects.

## What are the relevant tickets?

[CLI-1507](https://snyksec.atlassian.net/browse/CLI-1507)
--->

[CLI-1507]: https://snyksec.atlassian.net/browse/CLI-1507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ